### PR TITLE
trackman: increase modularity

### DIFF
--- a/wuvt/__init__.py
+++ b/wuvt/__init__.py
@@ -66,7 +66,26 @@ from wuvt import donate
 app.register_blueprint(donate.bp, url_prefix='/donate')
 
 from wuvt import trackman
-app.register_blueprint(trackman.bp, url_prefix='/trackman')
+app.register_blueprint(trackman.bp)
+app.register_blueprint(trackman.private_bp, url_prefix='/trackman')
+
+
+@app.context_processor
+def inject_nowplaying():
+    track = trackman.trackinfo()
+    if not track:
+        return {
+            'current_track': u"Not Available",
+            'current_dj': u"Not Available",
+            'current_dj_id': 0,
+        }
+
+    return {
+        'current_track': u"{artist} - {title}".format(**track),
+        'current_dj': track['dj'],
+        'current_dj_id': track['dj_id']
+    }
+
 
 from wuvt import models
 from wuvt import views

--- a/wuvt/templates/base.html
+++ b/wuvt/templates/base.html
@@ -24,7 +24,7 @@
         <ul>
             <li><strong>Currently on air:</strong> <span id="current_track">{{ current_track }}</span></li>
             <li><strong>Current DJ:</strong> <span id="current_dj">{% if current_dj_id > 0 -%}
-<a href="{{ url_for('playlists_dj_sets', dj_id=current_dj_id) }}">{{ current_dj }}</a>
+<a href="{{ url_for('trackman.playlists_dj_sets', dj_id=current_dj_id) }}">{{ current_dj }}</a>
 {% else -%}
 {{ current_dj }}{% endif -%}
 </span></li>
@@ -49,7 +49,7 @@
         {% block bubble %}
         <ul>
             <li><a href="{{ url_for('page', slug='listen-live') }}">Listen Live!</a></li>
-            <li><a href="{{ url_for('last15') }}">Last 15 Tracks!!</a></li>
+            <li><a href="{{ url_for('trackman.last15') }}">Last 15 Tracks!!</a></li>
             <li><a href="{{ url_for('page', slug='donate') }}">Donate Online!!!</a></li>
         </ul>
         {% endblock %}
@@ -64,10 +64,10 @@
                 <span class="menu-heading">{{ section['name'] }}</span>
                 <ul>
                     {% if section['menu'] == 'playlists' -%}
-                    <li><a href="{{ url_for('last15') }}">Last 15</a></li>
-                    <li><a href="{{ url_for('playlists_date') }}">by date</a></li>
-                    <li><a href="{{ url_for('playlists_dj') }}">by DJ</a></li>
-                    <li><a href="{{ url_for('charts_index') }}">Charts</a></li>
+                    <li><a href="{{ url_for('trackman.last15') }}">Last 15</a></li>
+                    <li><a href="{{ url_for('trackman.playlists_date') }}">by date</a></li>
+                    <li><a href="{{ url_for('trackman.playlists_dj') }}">by DJ</a></li>
+                    <li><a href="{{ url_for('trackman.charts_index') }}">Charts</a></li>
                     {% endif -%}
                     {% for page in menus[section['menu']] -%}
                     {% if page.published %}

--- a/wuvt/templates/chart_albums_dj.html
+++ b/wuvt/templates/chart_albums_dj.html
@@ -4,7 +4,7 @@
 <section>
 <header>
     <h2>Charts: Top Albums by DJ</h2>
-    <h3><a href="{{ url_for('playlists_dj_sets', dj_id=dj.id) }}">{{ dj.airname }}</a></h3>
+    <h3><a href="{{ url_for('trackman.playlists_dj_sets', dj_id=dj.id) }}">{{ dj.airname }}</a></h3>
 </header>
 
 <table class="tracklist chart">

--- a/wuvt/templates/chart_artists_dj.html
+++ b/wuvt/templates/chart_artists_dj.html
@@ -4,7 +4,7 @@
 <section>
 <header>
     <h2>Charts: Top Artists by DJ</h2>
-    <h3><a href="{{ url_for('playlists_dj_sets', dj_id=dj.id) }}">{{ dj.airname }}</a></h3>
+    <h3><a href="{{ url_for('trackman.playlists_dj_sets', dj_id=dj.id) }}">{{ dj.airname }}</a></h3>
 </header>
 
 <table class="tracklist chart">

--- a/wuvt/templates/chart_dj_spins.html
+++ b/wuvt/templates/chart_dj_spins.html
@@ -14,7 +14,7 @@
     <tbody>
         {% for dj_id, dj, spins in results %}
         <tr>
-            <td><a href="{{ url_for('playlists_dj_sets', dj_id=dj_id) }}">{{ dj.airname }}</a></td>
+            <td><a href="{{ url_for('trackman.playlists_dj_sets', dj_id=dj_id) }}">{{ dj.airname }}</a></td>
             <td class="text-right">{{ spins }}</td>
         </tr>
         {% endfor %}

--- a/wuvt/templates/chart_tracks_dj.html
+++ b/wuvt/templates/chart_tracks_dj.html
@@ -4,7 +4,7 @@
 <section>
 <header>
     <h2>Charts: Top Tracks by DJ</h2>
-    <h3><a href="{{ url_for('playlists_dj_sets', dj_id=dj.id) }}">{{ dj.airname }}</a></h3>
+    <h3><a href="{{ url_for('trackman.playlists_dj_sets', dj_id=dj.id) }}">{{ dj.airname }}</a></h3>
 </header>
 
 <table class="tracklist chart">

--- a/wuvt/templates/charts.html
+++ b/wuvt/templates/charts.html
@@ -17,7 +17,7 @@
     {% endfor %}
 
     <ul>
-        <li><a href="{{ url_for('charts_dj_spins') }}">Top DJs by spins</a></li>
+        <li><a href="{{ url_for('trackman.charts_dj_spins') }}">Top DJs by spins</a></li>
     </ul>
 </section>
 {% endblock %}

--- a/wuvt/templates/last15.html
+++ b/wuvt/templates/last15.html
@@ -29,7 +29,7 @@
             <td>{{ track.track.album }}</td>
             <td>
                 {% if track.dj.visible -%}
-                <a href="{{ url_for('playlists_dj_sets', dj_id=track.dj_id) }}">{{ track.dj.airname }}</a>
+                <a href="{{ url_for('trackman.playlists_dj_sets', dj_id=track.dj_id) }}">{{ track.dj.airname }}</a>
                 {% else -%}
                 {{ track.dj.airname }}
                 {% endif -%}
@@ -48,7 +48,7 @@
 </header>
 
 <p>Check out our playlist archives. You can search
-<a href='{{ url_for('playlists_date') }}'>air date</a> or
-<a href="{{ url_for('playlists_dj') }}">DJ</a>.</p>
+<a href='{{ url_for('trackman.playlists_date') }}'>air date</a> or
+<a href="{{ url_for('trackman.playlists_dj') }}">DJ</a>.</p>
 </section>
 {% endblock %}

--- a/wuvt/templates/playlist.html
+++ b/wuvt/templates/playlist.html
@@ -4,7 +4,7 @@
 <section>
 <header>
     <h2>Playlist Archive</h2>
-    <h3><a href="/playlists/dj/{{ djset.dj.id }}">{{ djset.dj.airname }}</a> / <time datetime="{{ djset.dtstart|isodatetime }}" data-format="YYYY-MM-DD HH:mm">{{ djset.dtstart|datetime("%Y-%m-%d %H:%M") }}</time></h3>
+    <h3><a href="{{ url_for('trackman.playlists_dj_sets', dj_id=djset.dj.id) }}">{{ djset.dj.airname }}</a> / <time datetime="{{ djset.dtstart|isodatetime }}" data-format="YYYY-MM-DD HH:mm">{{ djset.dtstart|datetime("%Y-%m-%d %H:%M") }}</time></h3>
 </header>
 <div class="links">
     <h4>Listen Online</h4>

--- a/wuvt/templates/playlists_date_sets.html
+++ b/wuvt/templates/playlists_date_sets.html
@@ -11,7 +11,7 @@
 <section>
     <ul>
         {% for set in sets %}
-        <li><a href="{{ url_for('playlist', set_id=set.id) }}"><time datetime="{{ set.dtstart|isodatetime }}" data-format="HH:mm">{{ set.dtstart|datetime("%H:%M") }}</time>-{% if set.dtend %}<time datetime="{{ set.dtend|isodatetime }}" data-format="HH:mm">>{{ set.dtend|datetime("%H:%M") }}</time>{% endif %}: {{ set.dj.airname }}</a></li>
+        <li><a href="{{ url_for('trackman.playlist', set_id=set.id) }}"><time datetime="{{ set.dtstart|isodatetime }}" data-format="HH:mm">{{ set.dtstart|datetime("%H:%M") }}</time>-{% if set.dtend %}<time datetime="{{ set.dtend|isodatetime }}" data-format="HH:mm">>{{ set.dtend|datetime("%H:%M") }}</time>{% endif %}: {{ set.dj.airname }}</a></li>
         {% endfor %}
     </ul>
 </section>

--- a/wuvt/templates/playlists_dj_list.html
+++ b/wuvt/templates/playlists_dj_list.html
@@ -9,12 +9,12 @@
 
     <ul>
         {% for dj in djs %}
-        <li><a href="{{ url_for('playlists_dj_sets', dj_id=dj.id) }}">{{ dj.airname }}</a></li>
+        <li><a href="{{ url_for('trackman.playlists_dj_sets', dj_id=dj.id) }}">{{ dj.airname }}</a></li>
         {% endfor %}
     </ul>
 </section>
 
 <section class="pagination">
-    <a href="{{ url_for('playlists_dj_all') }}">Show all DJs</a>
+    <a href="{{ url_for('trackman.playlists_dj_all') }}">Show all DJs</a>
 </section>
 {% endblock %}

--- a/wuvt/templates/playlists_dj_list_all.html
+++ b/wuvt/templates/playlists_dj_list_all.html
@@ -9,12 +9,12 @@
 
     <ul>
         {% for dj in djs %}
-        <li><a href="{{ url_for('playlists_dj_sets', dj_id=dj.id) }}">{{ dj.airname }}</a></li>
+        <li><a href="{{ url_for('trackman.playlists_dj_sets', dj_id=dj.id) }}">{{ dj.airname }}</a></li>
         {% endfor %}
     </ul>
 </section>
 
 <section class="pagination">
-    <a href="{{ url_for('playlists_dj') }}">Show only current DJs</a>
+    <a href="{{ url_for('trackman.playlists_dj') }}">Show only current DJs</a>
 </section>
 {% endblock %}

--- a/wuvt/templates/playlists_dj_sets.html
+++ b/wuvt/templates/playlists_dj_sets.html
@@ -10,7 +10,7 @@
 
     <ul>
         {% for set in sets %}
-        <li><a href="{{ url_for('playlist', set_id=set.id) }}"><time datetime="{{ set.dtstart|isodatetime }}" data-format="YYYY-MM-DD HH:mm">{{ set.dtstart|datetime("%Y-%m-%d %H:%M") }}</time>{% if set.dtend %}-<time datetime="{{ set.dtend|isodatetime }}" data-format="YYYY-MM-DD HH:mm">{{ set.dtend|datetime("%Y-%m-%d %H:%M") }}</time>{% endif %}</a></li>
+        <li><a href="{{ url_for('trackman.playlist', set_id=set.id) }}"><time datetime="{{ set.dtstart|isodatetime }}" data-format="YYYY-MM-DD HH:mm">{{ set.dtstart|datetime("%Y-%m-%d %H:%M") }}</time>{% if set.dtend %}-<time datetime="{{ set.dtend|isodatetime }}" data-format="YYYY-MM-DD HH:mm">{{ set.dtend|datetime("%Y-%m-%d %H:%M") }}</time>{% endif %}</a></li>
         {% endfor %}
     </ul>
 </section>
@@ -21,9 +21,9 @@
     </header>
 
     <ul>
-        <li><a href="{{ url_for('charts_albums_dj', dj_id=dj.id) }}">Top albums for this DJ</a></li>
-        <li><a href="{{ url_for('charts_artists_dj', dj_id=dj.id) }}">Top artists for this DJ</a></li>
-        <li><a href="{{ url_for('charts_tracks_dj', dj_id=dj.id) }}">Top tracks for this DJ</a></li>
+        <li><a href="{{ url_for('trackman.charts_albums_dj', dj_id=dj.id) }}">Top albums for this DJ</a></li>
+        <li><a href="{{ url_for('trackman.charts_artists_dj', dj_id=dj.id) }}">Top artists for this DJ</a></li>
+        <li><a href="{{ url_for('trackman.charts_tracks_dj', dj_id=dj.id) }}">Top tracks for this DJ</a></li>
 
     </ul>
 </section>

--- a/wuvt/templates/trackman/log.html
+++ b/wuvt/templates/trackman/log.html
@@ -1,6 +1,6 @@
 {% extends "trackman/base.html" %}
 {% block content %}
-<form style="display: none;" action="{{ url_for('trackman.logout', setid=djset.id) }}" method="post"
+<form style="display: none;" action="{{ url_for('trackman_private.logout', setid=djset.id) }}" method="post"
     id="trackman_logout_form">
     <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}" />
     <input type="hidden" name="email_playlist" value="0" />
@@ -233,5 +233,5 @@
 {% block js %}
 {{ super() }}
 <script src="{{ url_for('static', filename='js/trackman.js') }}"></script>
-<script src="{{ url_for('trackman.log_js', setid=djset.id) }}"></script>
+<script src="{{ url_for('trackman_private.log_js', setid=djset.id) }}"></script>
 {% endblock %}

--- a/wuvt/templates/trackman/login.html
+++ b/wuvt/templates/trackman/login.html
@@ -2,7 +2,7 @@
 {% block bodyattrib %} class="page-signin"{% endblock %}
 {% block content %}
 
-<form action="{{ url_for('trackman.login') }}" method="post" class="form-signin">
+<form action="{{ url_for('trackman_private.login') }}" method="post" class="form-signin">
     <h2 class="form-signin-heading">{{ trackman_name }}</h2>
 
     <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}" />
@@ -30,13 +30,13 @@
 </form>
 
 <div class="trackman-buttons">
-    <a href="{{ url_for('trackman.register') }}" class="btn btn-default">
+    <a href="{{ url_for('trackman_private.register') }}" class="btn btn-default">
         <span class="glyphicon glyphicon-wrench"></span>
         Register New DJ
     </a>
 </div>
 
-<form action="{{ url_for('trackman.start_automation') }}" method="post" id="automation_start_form">
+<form action="{{ url_for('trackman_private.start_automation') }}" method="post" id="automation_start_form">
     <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}" />
 </form>
 {% endblock %}

--- a/wuvt/templates/trackman/register.html
+++ b/wuvt/templates/trackman/register.html
@@ -8,7 +8,7 @@
 <div class="alert alert-danger">{{ msg }}</div>
 {% endfor %}
 
-<form action="{{ url_for('trackman.register') }}" method="post"
+<form action="{{ url_for('trackman_private.register') }}" method="post"
     class="form-horizontal" role="form">
     <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}" />
 
@@ -60,7 +60,7 @@
             Register DJ
         </button>
 
-        <a href="{{ url_for('trackman.login') }}" class="btn btn-default">
+        <a href="{{ url_for('trackman_private.login') }}" class="btn btn-default">
             <span class="glyphicon glyphicon-remove"></span>
             Cancel
         </a>

--- a/wuvt/templates/trackman/report.html
+++ b/wuvt/templates/trackman/report.html
@@ -28,7 +28,7 @@
 </div>
 
 <div class="row">
-<form action="{{ url_for('trackman.report_track', dj_id=dj.id, track_id=track.id) }}"
+<form action="{{ url_for('trackman_private.report_track', dj_id=dj.id, track_id=track.id) }}"
     method="post" class="" role="form">
     <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}" />
 

--- a/wuvt/trackman/__init__.py
+++ b/wuvt/trackman/__init__.py
@@ -1,5 +1,8 @@
 from flask import Blueprint
 
 bp = Blueprint('trackman', __name__)
+private_bp = Blueprint('trackman_private', __name__)
 
-from wuvt.trackman import admin_views
+from . import views
+from . import admin_views
+from .views import trackinfo

--- a/wuvt/trackman/lib.py
+++ b/wuvt/trackman/lib.py
@@ -12,12 +12,12 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 import email.utils
 
-from wuvt import app
-from wuvt import cache
-from wuvt import db
-from wuvt import redis_conn
-from wuvt import format_datetime, localize_datetime
-from wuvt.trackman.models import TrackLog, DJSet
+from .. import app
+from .. import cache
+from .. import db
+from .. import redis_conn
+from .. import format_datetime, localize_datetime
+from .models import TrackLog, DJSet
 
 CHART_PER_PAGE = 250
 CHART_TTL = 14400
@@ -27,7 +27,7 @@ def get_duplicates(model, attrs):
     dups = model.query.with_entities(
         *[getattr(model, attr) for attr in attrs]).group_by(
         *[getattr(model, attr) for attr in attrs]).having(db.and_(
-        *[db.func.count(getattr(model, attr)) > 1 for attr in attrs])).all()
+            *[db.func.count(getattr(model, attr)) > 1 for attr in attrs])).all()
     return dups
 
 
@@ -214,7 +214,7 @@ def log_track(track_id, djset_id, request=False, vinyl=False, new=False,
     album = track.track.album
     played = localize_datetime(track.played)
 
-    from wuvt.trackman import tasks
+    from . import tasks
     tasks.update_stream.delay(artist, title, album)
     tasks.update_tunein.delay(artist, title)
     tasks.update_lastfm.delay(artist, title, album, played)

--- a/wuvt/trackman/models.py
+++ b/wuvt/trackman/models.py
@@ -1,7 +1,7 @@
 import datetime
 
-from wuvt import app
-from wuvt import db
+from .. import app
+from .. import db
 
 
 class DJ(db.Model):

--- a/wuvt/trackman/tasks.py
+++ b/wuvt/trackman/tasks.py
@@ -7,12 +7,12 @@ from datetime import timedelta
 from celery.decorators import periodic_task, task
 from celery.task.schedules import crontab
 
-from wuvt import app
-from wuvt import db
-from wuvt import redis_conn
-from wuvt.celeryconfig import make_celery
-from wuvt.trackman.lib import get_duplicates, logout_all, enable_automation
-from wuvt.trackman.models import AirLog, DJSet, Track, TrackLog
+from .. import app
+from .. import db
+from .. import redis_conn
+from ..celeryconfig import make_celery
+from .lib import get_duplicates, logout_all, enable_automation
+from .models import AirLog, DJSet, Track, TrackLog
 
 celery = make_celery(app)
 

--- a/wuvt/trackman/view_utils.py
+++ b/wuvt/trackman/view_utils.py
@@ -1,7 +1,6 @@
+from flask import current_app
 from functools import wraps
-from flask import abort, request
-from wuvt import app
-from wuvt import redis_conn
+from .. import redis_conn
 
 
 def dj_interact(f):
@@ -14,7 +13,7 @@ def dj_interact(f):
         # logout/login must delete this dj_timeout
         expire = redis_conn.get('dj_timeout')
         if redis_conn.get('dj_timeout') is None:
-            expire = app.config['DJ_TIMEOUT']
+            expire = current_app.config['DJ_TIMEOUT']
 
         redis_conn.expire('dj_active', int(expire))
 

--- a/wuvt/views.py
+++ b/wuvt/views.py
@@ -8,7 +8,6 @@ from . import db
 from .models import User, Page
 from .blog.models import Article, Category
 from .blog.views import *
-from .trackman.views import *
 from .view_utils import IPAccessDeniedException
 
 


### PR DESCRIPTION
* Add a blueprint for public-facing views too, instead of registering on
  the app directly
* Rename existing blueprint to "private_bp"
* Use relative imports throughout the module
* Move trackinfo injector outside trackman module
* Use current_app where possible
* Use relative imports where necessary

In the long term, removing all of the "from .." imports will be
desirable, but this is going to take significantly more work.