### PR TITLE
Send CMJ charts to CHART_DEST in config.

### DIFF
--- a/wuvt/defaults.py
+++ b/wuvt/defaults.py
@@ -56,6 +56,7 @@ ARCHIVE_BASE_URL = ""
 ADMINS = []
 MAIL_FROM = "noreply@localhost"
 SMTP_SERVER = "localhost"
+CHART_DEST = "music@wuvt.vt.edu"
 
 PROXY_FIX = False
 PROXY_FIX_NUM_PROXIES = 1

--- a/wuvt/templates/email/new_chart.txt
+++ b/wuvt/templates/email/new_chart.txt
@@ -1,0 +1,5 @@
+New Music Chart for {{ timestamp }}
+
+{% for track in chart %}
+{{ track[2] }} : {{ track[0] }} - {{ track[1] }}
+{% endfor %}

--- a/wuvt/trackman/mail.py
+++ b/wuvt/trackman/mail.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from flask import current_app, render_template
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -56,3 +57,29 @@ def send_playlist(djset, tracks):
         current_app.logger.warning(
             "Trackman: Failed to send email for DJ set {0}: {1}".format(
                 djset.id, exc))
+
+def send_chart(chart):
+    print(chart)
+
+    msg = MIMEMultipart('alternative')
+    msg['Date'] = email.utils.formatdate()
+    msg['From'] = current_app.config['MAIL_FROM']
+    msg['To'] = current_app.config['CHART_DEST']
+    msg['Message-Id'] = email.utils.make_msgid()
+    msg['X-Mailer'] = "Trackman"
+    timestamp = datetime.now()
+    msg['Subject'] = u"[New Music Chart] {0}".format(
+        format_datetime(timestamp, "%Y-%m-%d"))
+
+    msg.attach(MIMEText(
+        render_template('email/new_chart.txt',
+                        chart=chart, timestamp=timestamp).encode('utf-8'),
+        'text'))
+    try:
+        s = smtplib.SMTP(current_app.config['SMTP_SERVER'])
+        s.sendmail(msg['From'], [msg['To']], msg.as_string())
+        s.quit()
+    except Exception as exc:
+        current_app.logger.warning(
+            "Trackman: Failed to send weekly chart - {0}".format(
+                exc))


### PR DESCRIPTION
New config options CHART_DEST which contains the email to send the charts to. Scheduled by default to send Monday at 0:00. Fixes #88 