### PR TITLE
Trackman: Add basic authorization controls

### DIFF
--- a/wuvt/trackman/admin_views.py
+++ b/wuvt/trackman/admin_views.py
@@ -32,6 +32,7 @@ def login():
             db.session.add(djset)
             db.session.commit()
 
+        session['dj_id'] = dj.id
         session['djset_id'] = djset.id
 
         return redirect(url_for('.log', setid=djset.id))
@@ -71,6 +72,7 @@ def login_all():
             db.session.add(djset)
             db.session.commit()
 
+        session['dj_id'] = dj.id
         session['djset_id'] = djset.id
 
         return redirect(url_for('.log', setid=djset.id))
@@ -111,6 +113,7 @@ def log(setid):
 Your session has ended; you were either automatically logged out for inactivity
 or you pressed the Logout button somewhere else.
 """)
+            session.pop('dj_id', None)
             session.pop('djset_id', None)
 
         return redirect(url_for('.login'))
@@ -146,6 +149,7 @@ def log_js(setid):
 @private_bp.route('/log/<int:setid>/end', methods=['POST'])
 @local_only
 def logout(setid):
+    session.pop('dj_id', None)
     session.pop('djset_id', None)
 
     djset = DJSet.query.get_or_404(setid)

--- a/wuvt/trackman/view_utils.py
+++ b/wuvt/trackman/view_utils.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 import email.utils
-from flask import current_app, request
+from flask import current_app, request, session
+from flask_restful import abort
 from functools import wraps
 from urlparse import urljoin
 from .. import db, format_datetime
@@ -90,3 +91,13 @@ TITLE "{date}"
             offset += len(tracks)
 
     return cuesheet
+
+
+def require_dj_session(f):
+    @wraps(f)
+    def require_dj_session_wrapper(*args, **kwargs):
+        if session.get('dj_id', None) is None:
+            abort(403, message="You must login as a DJ to use that feature.")
+        else:
+            return f(*args, **kwargs)
+    return require_dj_session_wrapper


### PR DESCRIPTION
There are many features in Trackman that we don't want to have
completely open. Although we are not putting authentication on the login
page yet, we can update the session dictionary with some additional
items. We can then use these items as authorization for certain
features.

This partially addresses #158.