### PR TITLE
Sign session UUID when using Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ It has several main components:
   card/Bitcoin transactions.
 
 ### Deployment
+These instructions are for Linux; instructions for other platforms may vary.
+
 First, clone the repo, create an empty config, and build the appropriate Docker
 image for your environment. We provide Dockerfile.dev which is configured to
 use SQLite and runs Redis directly in the image, and Dockerfile, which is
@@ -27,7 +29,7 @@ For Dockerfile.dev:
 ```
 git clone https://github.com/wuvt/wuvt-site.git
 cd wuvt-site
-touch wuvt/config.py
+echo "SECRET_KEY = \"$(xxd -l 28 -p /dev/urandom\"" > wuvt/config.py
 docker build -t wuvt-site -f Dockerfile.dev .
 ```
 
@@ -85,8 +87,9 @@ cd wuvt-site
 ```
 
 Create a blank file, wuvt/config.py; you can override any of the default
-configuration options here if you so desire. Next, you will need to render
-images, create the database, and add some sample content to the site:
+configuration options here if you so desire. You'll definitely need to set a
+value for `SECRET_KEY`. Next, you will need to render images, create the
+database, and add some sample content to the site:
 
 ```
 export FLASK_APP=$PWD/wuvt/__init__.py

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For Dockerfile.dev:
 ```
 git clone https://github.com/wuvt/wuvt-site.git
 cd wuvt-site
-echo "SECRET_KEY = \"$(xxd -l 28 -p /dev/urandom\"" > wuvt/config.py
+echo "SECRET_KEY = \"$(xxd -l 28 -p /dev/urandom)\"" > wuvt/config.py
 docker build -t wuvt-site -f Dockerfile.dev .
 ```
 


### PR DESCRIPTION
Even though the session UUID isn't sensitive or predictable, it doesn't
hurt to sign it and it makes it impossible to attempt to brute force or
otherwise tamper with session UUIDs.

When deploying this, note that this will invalidate the current session
and any data stored in it, such as the CSRF token, which will cause 403
errors for anyone who happens to submit a form that was loaded before
the deployment. It might be a good idea to manually restart Trackman on
the workstations to avoid DJ confusion.