### PR TITLE
Increase track column lengths

### DIFF
--- a/migrations/versions/ac0939a5ff73_increase_track_column_lengths.py
+++ b/migrations/versions/ac0939a5ff73_increase_track_column_lengths.py
@@ -1,0 +1,38 @@
+"""Increase track column lengths
+
+On Postgres, the columns will be set to unlimited length.
+
+Revision ID: ac0939a5ff73
+Revises: c4b654dc2af1
+Create Date: 2017-02-25 07:00:15.121508
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'ac0939a5ff73'
+down_revision = 'c4b654dc2af1'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.alter_column(
+        'track', 'title',
+        type_=sa.Unicode(500).with_variant(sa.Unicode, 'postgresql'))
+    op.alter_column(
+        'track', 'artist',
+        type_=sa.Unicode(255).with_variant(sa.Unicode, 'postgresql'))
+    op.alter_column(
+        'track', 'album',
+        type_=sa.Unicode(255).with_variant(sa.Unicode, 'postgresql'))
+    op.alter_column(
+        'track', 'label',
+        type_=sa.Unicode(255).with_variant(sa.Unicode, 'postgresql'))
+
+
+def downgrade():
+    op.alter_column('track', 'title', type_=sa.Unicode(255))
+    op.alter_column('track', 'artist', type_=sa.Unicode(255))
+    op.alter_column('track', 'album', type_=sa.Unicode(255))
+    op.alter_column('track', 'label', type_=sa.Unicode(255))

--- a/wuvt/trackman/models.py
+++ b/wuvt/trackman/models.py
@@ -171,10 +171,10 @@ class Track(db.Model):
     __tablename__ = "track"
     # may need to make this a BigInteger
     id = db.Column(db.Integer, primary_key=True)
-    title = db.Column(db.Unicode(255))
-    artist = db.Column(db.Unicode(255), index=True)
-    album = db.Column(db.Unicode(255))
-    label = db.Column(db.Unicode(255))
+    title = db.Column(db.Unicode(500).with_variant(db.Unicode, 'postgresql'))
+    artist = db.Column(db.Unicode(255).with_variant(db.Unicode, 'postgresql'), index=True)
+    album = db.Column(db.Unicode(255).with_variant(db.Unicode, 'postgresql'))
+    label = db.Column(db.Unicode(255).with_variant(db.Unicode, 'postgresql'))
     added = db.Column(db.DateTime, default=datetime.datetime.utcnow)
     artist_mbid = db.Column(UUIDType())
     recording_mbid = db.Column(UUIDType())


### PR DESCRIPTION
We ran into an issue with a particular Surfjan Stevens song that has a
title that is longer than 255 characters. Conveniently, Postgres
supports unlimited lengths for the Unicode column type, so we will use
that if available. If not, 500 characters for the title will do.