### PR TITLE
Use case-insensitive track matching in Trackman

### DIFF
--- a/wuvt/trackman/api.py
+++ b/wuvt/trackman/api.py
@@ -7,7 +7,7 @@ from . import api_bp, models
 from .forms import TrackAddForm, AutomationTrackLogForm, TrackLogForm, \
     TrackLogEditForm, AirLogForm, AirLogEditForm
 from .lib import disable_automation, fixup_current_track, log_track, \
-    logout_all_except
+    logout_all_except, find_or_add_track
 from .view_utils import dj_interact, require_dj_session
 
 
@@ -106,31 +106,25 @@ class AutomationLog(TrackmanPublicResource):
 
         label = form.label.data
         if len(label) > 0:
-            tracks = models.Track.query.filter(
-                models.Track.title == title,
-                models.Track.artist == artist,
-                models.Track.album == album,
-                models.Track.label == label)
-            if len(tracks.all()) == 0:
-                track = models.Track(title, artist, album, label)
-                db.session.add(track)
-                db.session.commit()
-            else:
-                track = tracks.first()
+            track = find_or_add_track(models.Track(
+                title,
+                artist,
+                album,
+                label))
         else:
             # Handle automation not providing a label
             label = u"Not Available"
             tracks = models.Track.query.filter(
-                models.Track.title == title,
-                models.Track.artist == artist,
-                models.Track.album == album)
-            if len(tracks.all()) == 0:
+                db.func.lower(models.Track.title) == db.func.lower(title),
+                db.func.lower(models.Track.artist) == db.func.lower(artist),
+                db.func.lower(models.Track.album) == db.func.lower(album))
+            if tracks.count() == 0:
                 track = models.Track(title, artist, album, label)
                 db.session.add(track)
                 db.session.commit()
             else:
                 notauto = tracks.filter(models.Track.label != u"Not Available")
-                if len(notauto.all()) == 0:
+                if notauto.count() == 0:
                     # The only option is "not available label"
                     track = tracks.first()
                 else:
@@ -702,13 +696,11 @@ class TrackList(TrackmanResource):
 
         form = TrackAddForm(meta={'csrf': False})
         if form.validate():
-            track = models.Track(
+            track = find_or_add_track(models.Track(
                 form.title.data,
                 form.artist.data,
                 form.album.data,
-                form.label.data)
-            db.session.add(track)
-            db.session.commit()
+                form.label.data))
 
             return {
                 'success': True,
@@ -836,9 +828,11 @@ class TrackLog(TrackmanResource):
                 album != tracklog.track.album or label != tracklog.track.label:
             # If not, this means we try to create a new track
             if form.validate():
-                track = models.Track(title, artist, album, label)
-                db.session.add(track)
-                db.session.commit()
+                track = find_or_add_track(models.Track(
+                    title,
+                    artist,
+                    album,
+                    label))
                 tracklog.track_id = track.id
             else:
                 abort(400, success=False, errors=form.errors,

--- a/wuvt/trackman/lib.py
+++ b/wuvt/trackman/lib.py
@@ -374,3 +374,17 @@ def cleanup_dj_list():
         dj.email = None
         dj.visible = False
         db.session.commit()
+
+
+def find_or_add_track(track):
+    match = Track.query.filter(
+        db.func.lower(Track.artist) == db.func.lower(track.artist),
+        db.func.lower(Track.title) == db.func.lower(track.title),
+        db.func.lower(Track.album) == db.func.lower(track.album),
+        db.func.lower(Track.label) == db.func.lower(track.label)).first()
+    if match is None:
+        db.session.add(track)
+        db.session.commit()
+        return track
+    else:
+        return match


### PR DESCRIPTION
There are several places where we check the database to see if a track
already exists in the database. We should use case-insensitive matching
for this in the Trackman API when possible.

This also fixes #150.