### PR TITLE
Individually autocomplete each field in Trackman

### DIFF
--- a/wuvt/static/js/trackman/trackman.js
+++ b/wuvt/static/js/trackman/trackman.js
@@ -611,17 +611,20 @@ Trackman.prototype.updateHistory = function() {
 Trackman.prototype.autoCompleteField = function(name) {
     var inst = this;
     var searchData = this.getFormData();
+    var acData = {};
 
     if(name == 'rlabel') {
-        searchData['field'] = "label";
+        acData['field'] = "label";
+        acData['label'] = searchData['label'];
     }
     else {
-        searchData['field'] = name;
+        acData['field'] = name;
+        acData[name] = searchData[name];
     }
 
     $.ajax({
         url: "/trackman/api/autocomplete",
-        data: searchData,
+        data: acData,
         dataType: "json",
         success: function(data) {
             if(data['success'] == false) {

--- a/wuvt/templates/trackman/log.html
+++ b/wuvt/templates/trackman/log.html
@@ -305,6 +305,6 @@
 {% endblock %}
 {% block js %}
 {{ super() }}
-<script src="{{ url_for('static', filename='js/trackman/trackman.js', v=6) }}"></script>
+<script src="{{ url_for('static', filename='js/trackman/trackman.js', v=7) }}"></script>
 <script src="{{ url_for('trackman_private.log_js', setid=djset.id) }}"></script>
 {% endblock %}

--- a/wuvt/trackman/api.py
+++ b/wuvt/trackman/api.py
@@ -581,31 +581,29 @@ class TrackAutoComplete(TrackmanResource):
 
         tracks = base_query
 
-        # Do case-insensitive exact matching first
-
         artist = request.args.get('artist', '').strip()
         if len(artist) > 0:
             somesearch = True
             tracks = tracks.filter(
-                db.func.lower(models.Track.artist) == db.func.lower(artist))
+                models.Track.artist.ilike('{0}%'.format(artist)))
 
         title = request.args.get('title', '').strip()
         if len(title) > 0:
             somesearch = True
             tracks = tracks.filter(
-                db.func.lower(models.Track.title) == db.func.lower(title))
+                models.Track.title.ilike('{0}%'.format(title)))
 
         album = request.args.get('album', '').strip()
         if len(album) > 0:
             somesearch = True
             tracks = tracks.filter(
-                db.func.lower(models.Track.album) == db.func.lower(album))
+                models.Track.album.ilike('{0}%'.format(album)))
 
         label = request.args.get('label', '').strip()
         if len(label) > 0:
             somesearch = True
             tracks = tracks.filter(
-                db.func.lower(models.Track.label) == db.func.lower(label))
+                models.Track.label.ilike('{0}%'.format(label)))
 
         # This means there was a bad search, stop searching
         if somesearch is False:
@@ -613,37 +611,7 @@ class TrackAutoComplete(TrackmanResource):
 
         # Check if results
 
-        tracks = tracks.limit(8).all()
-        if len(tracks) == 0:
-            tracks = base_query
-
-            # if there are too few results, append some similar results
-            artist = request.args.get('artist', '').strip()
-            if len(artist) > 0:
-                somesearch = True
-                tracks = tracks.filter(
-                    models.Track.artist.ilike(''.join(['%', artist, '%'])))
-
-            title = request.args.get('title', '').strip()
-            if len(title) > 0:
-                somesearch = True
-                tracks = tracks.filter(
-                    models.Track.title.ilike(''.join(['%', title, '%'])))
-
-            album = request.args.get('album', '').strip()
-            if len(album) > 0:
-                somesearch = True
-                tracks = tracks.filter(
-                    models.Track.album.ilike(''.join(['%', album, '%'])))
-
-            label = request.args.get('label', '').strip()
-            if len(label) > 0:
-                somesearch = True
-                tracks = tracks.filter(
-                    models.Track.label.ilike(''.join(['%', label, '%'])))
-
-            tracks = tracks.limit(8).all()
-
+        tracks = tracks.limit(25).all()
         if len(tracks) > 0:
             results = [t[0] for t in tracks]
         else:


### PR DESCRIPTION
Previously, we were autocompleting based on the possible entries for
each field. This wasn't very intuitive for DJs and it made it
frustrating if a particular track didn't exist, but all the other
metadata did.

The solution is to autocomplete each field individually. We may still
have to make some tweaks to the sort order, but this should be a big
improvement.