### PR TITLE
Rollback failed transactions in SQLAlchemy

### DIFF
--- a/wuvt/admin/auth/views.py
+++ b/wuvt/admin/auth/views.py
@@ -31,7 +31,12 @@ def role_add_user():
                 flash("That role was already assigned to that user.")
             else:
                 db.session.add(UserRole(user_id, role))
-                db.session.commit()
+
+                try:
+                    db.session.commit()
+                except:
+                    db.session.rollback()
+                    raise
 
                 flash("The role has been assigned to the user.")
 
@@ -49,7 +54,12 @@ def role_add_user():
 def role_remove_user(id):
     user_role = UserRole.query.get_or_404(id)
     db.session.delete(user_role)
-    db.session.commit()
+
+    try:
+        db.session.commit()
+    except:
+        db.session.rollback()
+        raise
 
     if request.method == 'DELETE' or request.wants_json():
         return jsonify({
@@ -80,7 +90,11 @@ def role_add_group():
                 flash("That role was already assigned to that group.")
             else:
                 db.session.add(GroupRole(group, role))
-                db.session.commit()
+                try:
+                    db.session.commit()
+                except:
+                    db.session.rollback()
+                    raise
 
                 flash("The role has been assigned to the group.")
 
@@ -96,7 +110,11 @@ def role_add_group():
 def role_remove_group(id):
     group_role = GroupRole.query.get_or_404(id)
     db.session.delete(group_role)
-    db.session.commit()
+    try:
+        db.session.commit()
+    except:
+        db.session.rollback()
+        raise
 
     if request.method == 'DELETE' or request.wants_json():
         return jsonify({
@@ -135,10 +153,21 @@ def user_add():
     if form.validate_on_submit():
         db.session.add(User(form.username.data, form.name.data,
                             form.email.data))
-        db.session.commit()
+
+        try:
+            db.session.commit()
+        except:
+            db.session.rollback()
+            raise
+
         user = User.query.filter_by(username=form.username.data).first()
         user.set_password(form.data.password)
-        db.session.commit()
+
+        try:
+            db.session.commit()
+        except:
+            db.session.rollback()
+            raise
 
         flash("User added.")
         return redirect(url_for('admin.users'), 303)
@@ -172,7 +201,11 @@ def user_edit(id):
             user.set_password(form.newpass.data)
         # TODO reset password to pw
 
-        db.session.commit()
+        try:
+            db.session.commit()
+        except:
+            db.session.rollback()
+            raise
 
         flash('User updated.')
         return redirect(url_for('admin.users'), 303)

--- a/wuvt/admin/library/views.py
+++ b/wuvt/admin/library/views.py
@@ -212,7 +212,12 @@ def library_track(id):
             track.title = title
             track.album = album
             track.label = label
-            db.session.commit()
+
+            try:
+                db.session.commit()
+            except:
+                db.session.rollback()
+                raise
 
             # merge with any tracks that exactly match
             deduplicate_track_by_id(id)
@@ -246,7 +251,12 @@ def library_track_musicbrainz(id):
             track.recording_mbid = None
             track.release_mbid = None
             track.releasegroup_mbid = None
-            db.session.commit()
+
+            try:
+                db.session.commit()
+            except:
+                db.session.rollback()
+                raise
 
             flash("The MusicBrainz IDs for the track have been cleared.")
             return redirect(url_for('admin.library_track', id=track.id,
@@ -314,7 +324,11 @@ def library_track_musicbrainz(id):
         else:
             track.releasegroup_mbid = None
 
-        db.session.commit()
+        try:
+            db.session.commit()
+        except:
+            db.session.rollback()
+            raise
 
         return redirect(url_for('admin.library_track', id=track.id,
                                 **{'from': edit_from}))
@@ -356,7 +370,11 @@ def library_track_similar(id, page=1):
             Track.query.filter(Track.id.in_(merge)).delete(
                 synchronize_session=False)
 
-            db.session.commit()
+            try:
+                db.session.commit()
+            except:
+                db.session.rollback()
+                raise
 
             current_app.logger.warning(
                 "Trackman: Merged tracks {0} into track {1}".format(

--- a/wuvt/admin/views.py
+++ b/wuvt/admin/views.py
@@ -90,7 +90,12 @@ def category_add():
                 slug += '-'
 
             db.session.add(Category(name, slug, published))
-            db.session.commit()
+
+            try:
+                db.session.commit()
+            except:
+                db.session.rollback()
+                raise
 
             cache.set('blog_categories', list_categories())
 
@@ -130,7 +135,12 @@ def category_edit(cat_id):
             category.name = name
             category.slug = slug
             category.published = published
-            db.session.commit()
+
+            try:
+                db.session.commit()
+            except:
+                db.session.rollback()
+                raise
 
             cache.set('blog_categories', list_categories())
 
@@ -138,7 +148,12 @@ def category_edit(cat_id):
             return redirect(url_for('admin.categories'))
     elif request.method == 'DELETE':
         db.session.delete(category)
-        db.session.commit()
+
+        try:
+            db.session.commit()
+        except:
+            db.session.rollback()
+            raise
 
         cache.set('blog_categories', list_categories())
 
@@ -226,7 +241,12 @@ def page_edit(page_id):
             page.content = content
 
             page.update_content(content)    # render HTML
-            db.session.commit()
+
+            try:
+                db.session.commit()
+            except:
+                db.session.rollback()
+                raise
 
             cache.set('menus', get_menus())
 
@@ -288,7 +308,12 @@ def page_add():
             page = Page(title, slug, content, published, section)
 
             db.session.add(page)
-            db.session.commit()
+
+            try:
+                db.session.commit()
+            except:
+                db.session.rollback()
+                raise
 
             cache.set('menus', get_menus())
 
@@ -360,7 +385,11 @@ def article_add():
 
             db.session.add(article)
             article.render_html()   # markdown to html
-            db.session.commit()
+            try:
+                db.session.commit()
+            except:
+                db.session.rollback()
+                raise
 
             flash("Article Saved")
             return redirect(url_for('admin.articles'))
@@ -438,15 +467,27 @@ def article_edit(art_id):
             article.summary = summary
             article.content = content
             article.front_page = front_page
-            db.session.commit()
+            try:
+                db.session.commit()
+            except:
+                db.session.rollback()
+                raise
             article.render_html()
-            db.session.commit()
+            try:
+                db.session.commit()
+            except:
+                db.session.rollback()
+                raise
 
             flash("Article Saved")
             return redirect(url_for('admin.articles'))
     elif request.method == 'DELETE':
         db.session.delete(article)
-        db.session.commit()
+        try:
+            db.session.commit()
+        except:
+            db.session.rollback()
+            raise
 
         return jsonify({
             '_csrf_token': app.jinja_env.globals['csrf_token'](),

--- a/wuvt/auth/views.py
+++ b/wuvt/auth/views.py
@@ -17,12 +17,16 @@ def _find_or_create_user(username, name, email):
         # create new user in the database, since one doesn't already exist
         user = User(username, name, email)
         db.session.add(user)
-        db.session.commit()
     else:
         # update existing user data in database
         user.name = name
         user.email = email
+
+    try:
         db.session.commit()
+    except:
+        db.session.rollback()
+        raise
 
     return user
 

--- a/wuvt/cli.py
+++ b/wuvt/cli.py
@@ -18,7 +18,11 @@ def initdb(username, password):
 
     dj = DJ(u"Automation", u"Automation", False)
     db.session.add(dj)
-    db.session.commit()
+    try:
+        db.session.commit()
+    except:
+        db.session.rollback()
+        raise
 
     cats = [Category(u"Events", u"events", True),
             Category(u"Music Adds", u"music-adds", True),
@@ -39,7 +43,11 @@ def initdb(username, password):
     db.session.add(Rotation(u"None"))
     map(db.session.add, map(Rotation, [u"Metal", u"New Music", u"Jazz", u"Rock", u"Americana"]))
 
-    db.session.commit()
+    try:
+        db.session.commit()
+    except:
+        db.session.rollback()
+        raise
 
     click.echo("Database initialized.")
 

--- a/wuvt/donate/views.py
+++ b/wuvt/donate/views.py
@@ -97,7 +97,11 @@ def process_order(method):
             order.set_paid(method)
 
     db.session.add(order)
-    db.session.commit()
+    try:
+        db.session.commit()
+    except:
+        db.session.rollback()
+        raise
     return True, "Thanks for your order!"
 
 

--- a/wuvt/sample_data.py
+++ b/wuvt/sample_data.py
@@ -40,7 +40,11 @@ fact that you bought the dream.
     article.front_page = True
     db.session.add(article)
     article.render_html()
-    db.session.commit()
+    try:
+        db.session.commit()
+    except:
+        db.session.rollback()
+        raise
 
     article = Article(u"Hudson Hits Another Buzzer Beater in Hokies Win",
                       u'hudson-hits-another-buzzer-beater-in-hokies-win', 1, 1,
@@ -75,7 +79,11 @@ crew but my mind didn't change you won't ever have to hide qui.
     article.front_page = True
     db.session.add(article)
     article.render_html()
-    db.session.commit()
+    try:
+        db.session.commit()
+    except:
+        db.session.rollback()
+        raise
 
 
 def add_sample_pages():
@@ -101,15 +109,27 @@ Nam feugiat porta commodo. Vestibulum tellus arcu, sollicitudin luctus vulputate
 
 Mauris egestas lectus dolor. Donec non augue id tellus volutpat ultricies. Sed consectetur magna semper tincidunt bibendum. Cras eget tempus orci. Cras pharetra ex in mauris placerat, vitae facilisis nisl egestas. Sed molestie ex mollis dolor congue posuere. Nulla sagittis lacinia tempus. Nulla et vestibulum diam. Cras id molestie metus. Aenean condimentum tellus sapien, at aliquam dui consequat vel. Cras posuere ultrices lectus. Quisque placerat velit lorem, volutpat rhoncus turpis sodales ac. Sed viverra mi elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 """, True, u"contact"))
-    db.session.commit()
+    try:
+        db.session.commit()
+    except:
+        db.session.rollback()
+        raise
 
 
 def add_sample_djs():
     db.session.add(DJ(u'Testy McTesterson', u'Testy McTesterson'))
-    db.session.commit()
+    try:
+        db.session.commit()
+    except:
+        db.session.rollback()
+        raise
 
 
 def add_sample_tracks():
     db.session.add(Track(u'The Divine Conspiracy', u'Epica', u'The Divine Conspiracy', u'Avalon'))
     db.session.add(Track(u'Second Stone', u'Epica', u'The Quantum Enigma', u'Nuclear Blast'))
-    db.session.commit()
+    try:
+        db.session.commit()
+    except:
+        db.session.rollback()
+        raise

--- a/wuvt/trackman/admin_views.py
+++ b/wuvt/trackman/admin_views.py
@@ -31,7 +31,11 @@ def login():
         if djset is None:
             djset = DJSet(dj.id)
             db.session.add(djset)
-            db.session.commit()
+            try:
+                db.session.commit()
+            except:
+                db.session.rollback()
+                raise
 
         session['dj_id'] = dj.id
         session['djset_id'] = djset.id
@@ -58,7 +62,11 @@ def login_all():
 
         dj = DJ.query.get(request.form['dj'])
         dj.visible = True
-        db.session.commit()
+        try:
+            db.session.commit()
+        except:
+            db.session.rollback()
+            raise
 
         current_app.logger.warning(
             "Trackman: {airname} logged in from {ip} using {ua}".format(
@@ -71,7 +79,11 @@ def login_all():
         if djset is None:
             djset = DJSet(dj.id)
             db.session.add(djset)
-            db.session.commit()
+            try:
+                db.session.commit()
+            except:
+                db.session.rollback()
+                raise
 
         session['dj_id'] = dj.id
         session['djset_id'] = djset.id
@@ -159,7 +171,12 @@ def logout(setid):
     else:
         # This has already been logged out
         return redirect(url_for('.login'))
-    db.session.commit()
+
+    try:
+        db.session.commit()
+    except:
+        db.session.rollback()
+        raise
 
     redis_conn.publish('trackman_dj_live', json.dumps({
         'event': "session_end",
@@ -196,7 +213,11 @@ def register():
             newdj.phone = form.phone.data
             newdj.genres = form.genres.data
             db.session.add(newdj)
-            db.session.commit()
+            try:
+                db.session.commit()
+            except:
+                db.session.rollback()
+                raise
 
             if request.wants_json():
                 return jsonify(success=True)
@@ -227,7 +248,11 @@ def reactivate_dj(setid):
         if form.validate():
             djset.dj.email = form.email.data
             djset.dj.phone = form.phone.data
-            db.session.commit()
+            try:
+                db.session.commit()
+            except:
+                db.session.rollback()
+                raise
 
             if request.wants_json():
                 return jsonify(success=True)

--- a/wuvt/trackman/api.py
+++ b/wuvt/trackman/api.py
@@ -114,7 +114,11 @@ class AutomationLog(TrackmanPublicResource):
             if len(tracks.all()) == 0:
                 track = models.Track(title, artist, album, label)
                 db.session.add(track)
-                db.session.commit()
+                try:
+                    db.session.commit()
+                except:
+                    db.session.rollback()
+                    raise
             else:
                 track = tracks.first()
         else:
@@ -127,7 +131,11 @@ class AutomationLog(TrackmanPublicResource):
             if len(tracks.all()) == 0:
                 track = models.Track(title, artist, album, label)
                 db.session.add(track)
-                db.session.commit()
+                try:
+                    db.session.commit()
+                except:
+                    db.session.rollback()
+                    raise
             else:
                 notauto = tracks.filter(models.Track.label != u"Not Available")
                 if len(notauto.all()) == 0:
@@ -179,7 +187,11 @@ class DJ(TrackmanResource):
                 abort(403, success=False,
                       message="DJs cannot be hidden through this API.")
 
-        db.session.commit()
+        try:
+            db.session.commit()
+        except:
+            db.session.rollback()
+            raise
 
         return {
             'success': True,
@@ -275,7 +287,11 @@ class DJSetList(TrackmanPublicResource):
         if djset is None:
             djset = DJSet(dj.id)
             db.session.add(djset)
-            db.session.commit()
+            try:
+                db.session.commit()
+            except:
+                db.session.rollback()
+                raise
 
         session['dj_id'] = dj.id
         session['djset_id'] = djset.id
@@ -359,7 +375,11 @@ class TrackReport(TrackmanResource):
 
         report = models.TrackReport(dj_id, track_id, reason)
         db.session.add(report)
-        db.session.commit()
+        try:
+            db.session.commit()
+        except:
+            db.session.rollback()
+            raise
 
         return {
             'success': True,
@@ -708,7 +728,11 @@ class TrackList(TrackmanResource):
                 form.album.data,
                 form.label.data)
             db.session.add(track)
-            db.session.commit()
+            try:
+                db.session.commit()
+            except:
+                db.session.rollback()
+                raise
 
             return {
                 'success': True,
@@ -770,7 +794,11 @@ class TrackLog(TrackmanResource):
         tracklog = self._load(tracklog_id)
         current_tracklog_id = self._get_current_id()
         db.session.delete(tracklog)
-        db.session.commit()
+        try:
+            db.session.commit()
+        except:
+            db.session.rollback()
+            raise
 
         if tracklog_id == current_tracklog_id:
             fixup_current_track("track_delete")
@@ -838,7 +866,11 @@ class TrackLog(TrackmanResource):
             if form.validate():
                 track = models.Track(title, artist, album, label)
                 db.session.add(track)
-                db.session.commit()
+                try:
+                    db.session.commit()
+                except:
+                    db.session.rollback()
+                    raise
                 tracklog.track_id = track.id
             else:
                 abort(400, success=False, errors=form.errors,
@@ -861,7 +893,11 @@ class TrackLog(TrackmanResource):
                   message="Rotation specified by rotation_id does not exist")
         tracklog.rotation_id = rotation.id
 
-        db.session.commit()
+        try:
+            db.session.commit()
+        except:
+            db.session.rollback()
+            raise
 
         if tracklog_id == current_tracklog_id:
             fixup_current_track()
@@ -1050,7 +1086,11 @@ class AirLog(TrackmanResource):
             abort(404, success=False, message="AirLog entry not found")
 
         db.session.delete(airlog)
-        db.session.commit()
+        try:
+            db.session.commit()
+        except:
+            db.session.rollback()
+            raise
 
         return {'success': True}
 
@@ -1113,7 +1153,11 @@ class AirLog(TrackmanResource):
         if logid > 0:
             airlog.logid = logid
 
-        db.session.commit()
+        try:
+            db.session.commit()
+        except:
+            db.session.rollback()
+            raise
 
         return {'success': True}
 
@@ -1165,7 +1209,11 @@ class AirLogList(TrackmanResource):
 
         airlog = models.AirLog(djset_id, form.logtype.data, form.logid.data)
         db.session.add(airlog)
-        db.session.commit()
+        try:
+            db.session.commit()
+        except:
+            db.session.rollback()
+            raise
 
         return {
             'success': True,


### PR DESCRIPTION
If a commit fails, we need to roll it back. Otherwise, the connection
will be released back to the pool in a broken state.

This change fixes the issues we've seen with database connectivity after
the database server is taken offline for maintenance and the site is
under load.