### PR TITLE
Fix rotation select in search results

### DIFF
--- a/wuvt/static/js/trackman/trackman.js
+++ b/wuvt/static/js/trackman/trackman.js
@@ -773,9 +773,8 @@ Trackman.prototype.renderSearchRow = function(i, track) {
     row.append(td);
 
     var td = $('<td>');
-    td.addClass('rotation');
     var newSelect = $('<select>');
-    this.renderRotation(newSelect);
+    newSelect.addClass('rotation');
     td.html(newSelect);
     row.append(td);
 

--- a/wuvt/templates/trackman/log.html
+++ b/wuvt/templates/trackman/log.html
@@ -305,6 +305,6 @@
 {% endblock %}
 {% block js %}
 {{ super() }}
-<script src="{{ url_for('static', filename='js/trackman/trackman.js', v=8) }}"></script>
+<script src="{{ url_for('static', filename='js/trackman/trackman.js', v=9) }}"></script>
 <script src="{{ url_for('trackman_private.log_js', setid=djset.id) }}"></script>
 {% endblock %}


### PR DESCRIPTION
The `rotation` class was being set on the `td` instead of the `select`
element, which prevented the rotation from being properly selected when
logging or adding a track to the queue. This change fixes that and
removes the extra `renderRotation` call.