### PR TITLE
Adjust pause event trigger on .trackman-entry input

### DIFF
--- a/wuvt/static/js/trackman/trackman.js
+++ b/wuvt/static/js/trackman/trackman.js
@@ -315,7 +315,7 @@ Trackman.prototype.initPlaylist = function() {
         }, 350);
     }
 
-    $(".trackman-entry").on('mouseover', function () {
+    $(".trackman-entry input").on('mouseover', function () {
         inst.pauseComplete = true;
     });
     $(".trackman-entry input").on('blur', function () {


### PR DESCRIPTION
We shouldn't need to pause the auto-completion events unless the
mouseover event occurs on one of the inputs.