### PR TITLE
Automatically resize Trackman to fit window

### DIFF
--- a/wuvt/static/css/admin.css
+++ b/wuvt/static/css/admin.css
@@ -113,8 +113,91 @@ td.row-options {
     margin-right: 5px;
 }
 
+.trackman-panel .table {
+    table-layout: fixed;
+}
+
+.trackman-panel .table th,
+.trackman-panel .table td {
+    overflow: hidden;
+}
+
+#trackman_playlist_panel .table th:nth-child(1),
+#trackman_playlist_panel .table td:nth-child(1) {
+    width: 5%;
+}
+
+#trackman_playlist_panel .table th:nth-child(2),
+#trackman_playlist_panel .table td:nth-child(2),
+#trackman_playlist_panel .table th:nth-child(3),
+#trackman_playlist_panel .table td:nth-child(3),
+#trackman_playlist_panel .table th:nth-child(4),
+#trackman_playlist_panel .table td:nth-child(4),
+#trackman_playlist_panel .table th:nth-child(5),
+#trackman_playlist_panel .table td:nth-child(5) {
+    width: 14%;
+}
+
+#trackman_playlist_panel .table th:nth-child(6),
+#trackman_playlist_panel .table td:nth-child(6),
+#trackman_playlist_panel .table th:nth-child(7),
+#trackman_playlist_panel .table td:nth-child(7),
+#trackman_playlist_panel .table th:nth-child(8),
+#trackman_playlist_panel .table td:nth-child(8) {
+    width: 5%;
+}
+
+#trackman_playlist_panel .table th:nth-child(9),
+#trackman_playlist_panel .table td:nth-child(9) {
+    width: 10%;
+}
+
+#trackman_queue_panel .table th:nth-child(1),
+#trackman_queue_panel .table td:nth-child(1),
+#trackman_search_panel .table th:nth-child(1),
+#trackman_search_panel .table td:nth-child(1) {
+    width: 16%;
+}
+
+#trackman_queue_panel .table th:nth-child(2),
+#trackman_queue_panel .table td:nth-child(2),
+#trackman_queue_panel .table th:nth-child(3),
+#trackman_queue_panel .table td:nth-child(3),
+#trackman_queue_panel .table th:nth-child(4),
+#trackman_queue_panel .table td:nth-child(4),
+#trackman_search_panel .table th:nth-child(2),
+#trackman_search_panel .table td:nth-child(2),
+#trackman_search_panel .table th:nth-child(3),
+#trackman_search_panel .table td:nth-child(3),
+#trackman_search_panel .table th:nth-child(4),
+#trackman_search_panel .table td:nth-child(4) {
+    width: 15%;
+}
+
+#trackman_queue_panel .table th:nth-child(5),
+#trackman_queue_panel .table td:nth-child(5),
+#trackman_queue_panel .table th:nth-child(6),
+#trackman_queue_panel .table td:nth-child(6),
+#trackman_queue_panel .table th:nth-child(7),
+#trackman_queue_panel .table td:nth-child(7),
+#trackman_search_panel .table th:nth-child(5),
+#trackman_search_panel .table td:nth-child(5),
+#trackman_search_panel .table th:nth-child(6),
+#trackman_search_panel .table td:nth-child(6),
+#trackman_search_panel .table th:nth-child(7),
+#trackman_search_panel .table td:nth-child(7) {
+    width: 5%;
+}
+
+#trackman_queue_panel .table th:nth-child(8),
+#trackman_queue_panel .table td:nth-child(8),
+#trackman_search_panel .table th:nth-child(8),
+#trackman_search_panel .table td:nth-child(8) {
+    width: 10%;
+}
+
 .row-table {
-    height: 240px;
+    height: 160px;
     overflow-y: auto;
 }
 

--- a/wuvt/static/js/trackman/trackman.js
+++ b/wuvt/static/js/trackman/trackman.js
@@ -1213,6 +1213,37 @@ Trackman.prototype.initEventHandler = function() {
     };
 };
 
+Trackman.prototype.adjustPanelHeights = function() {
+    var rowTableHeight = ($(window).height() - $('nav').height() - $('.trackman-entry').height() - 20 * 8) / 3 - $('#trackman_playlist_panel > .table:first-child').height();
+
+    // enforce a minimum height of 50 pixels
+    if(rowTableHeight < 50) {
+        rowTableHeight = 50;
+    }
+
+    $('.row-table').height(rowTableHeight);
+};
+
+Trackman.prototype.initResizeHandler = function() {
+    var inst = this;
+    var resizeTimeout;
+
+    // do an immediate resize
+    this.adjustPanelHeights();
+
+    // The MDN documentation indicates that this event handler shouldn't
+    // execute computationally expensive operations directly since it can fire
+    // at a high rate, so we throttle resize events to 15 fps
+    $(window).on('resize', null, {}, function() {
+        if(!resizeTimeout) {
+            resizeTimer = setTimeout(function() {
+                resizeTimeout = null;
+                inst.adjustPanelHeights();
+            }, 66);
+        }
+    });
+};
+
 Trackman.prototype.init = function() {
     var inst = this;
     $('#trackman_logout_form').bind('submit', {}, function() {
@@ -1220,6 +1251,7 @@ Trackman.prototype.init = function() {
         inst.saveQueue();
     });
 
+    this.initResizeHandler();
     this.initEventHandler();
     this.initAutologout();
     this.initQueue();

--- a/wuvt/templates/trackman/base.html
+++ b/wuvt/templates/trackman/base.html
@@ -7,7 +7,7 @@
 
         <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='bootstrap/css/bootstrap.min.css') }}" />
         <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='bootstrap/css/bootstrap-theme.min.css') }}" />
-        <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/admin.css', v=3) }}" />
+        <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/admin.css', v=4) }}" />
 
         <link rel="shortcut icon"
             href="{{ url_for('static', filename='img/favicon.ico') }}" />

--- a/wuvt/templates/trackman/log.html
+++ b/wuvt/templates/trackman/log.html
@@ -69,23 +69,26 @@
 {% block content %}
 <div class="floating-alerts" id="trackman_alerts"></div> 
 
-<div class="panel panel-default">
+<div class="panel panel-default trackman-panel" id="trackman_playlist_panel">
+    <table class='table table-condensed'>
+        <thead title="This is a list of the tracks you've played. If you need to make any changes or corrections, you can do that here.">
+            <tr>
+                <th>Time</th>
+                <th>Artist</th>
+                <th>Title</th>
+                <th>Album</th>
+                <th>Label</th>
+                <th>Request</th>
+                <th>Vinyl</th>
+                <th>New</th>
+                <th>Rotation</th>
+                <th></th>
+            </tr>
+        </thead>
+    </table>
+
     <div class="row-table">
         <table class='table table-condensed table-striped table-hover' id="playlist">
-            <thead title="This is a list of the tracks you've played. If you need to make any changes or corrections, you can do that here.">
-                <tr>
-                    <th>Time</th>
-                    <th>Artist</th>
-                    <th>Title</th>
-                    <th>Album</th>
-                    <th>Label</th>
-                    <th>Request</th>
-                    <th>Vinyl</th>
-                    <th>New</th>
-                    <th>Rotation</th>
-                    <th></th>
-                </tr>
-            </thead>
             <tbody>
             </tbody>
         </table>
@@ -211,47 +214,54 @@
 </div>
 -->
 
-<div class="panel panel-default">
+<div class="panel panel-default trackman-panel" id="trackman_queue_panel">
+    <table class='table table-condensed'>
+        <thead title="This is your queue. You can enter tracks ahead of time and access them from here. When you're ready to play them, just press their play button.">
+            <tr>
+                <th>Artist</th>
+                <th>Title</th>
+                <th>Album</th>
+                <th>Label</th>
+                <th>Request</th>
+                <th>Vinyl</th>
+                <th>New</th>
+                <th>Rotation</th>
+                <th></th>
+            </tr>
+        </thead>
+    </table>
+
     <div class="row-table trackman-queue">
         <table class='table table-condensed table-striped table-hover' id='queue'>
-            <thead title="This is your queue. You can enter tracks ahead of time and access them from here. When you're ready to play them, just press their play button.">
-                <tr>
-                    <th>Artist</th>
-                    <th>Title</th>
-                    <th>Album</th>
-                    <th>Label</th>
-                    <th>Request</th>
-                    <th>Vinyl</th>
-                    <th>New</th>
-                    <th>Rotation</th>
-                    <th></th>
-                </tr>
-            </thead>
             <tbody>
             </tbody>
         </table>
     </div>
 </div>
 
-<div class="panel panel-default">
+<div class="panel panel-default trackman-panel" id="trackman_search_panel">
     <div class="panel-heading">
         <h3 class="panel-title">Search Results</h3>
     </div>
+
+    <table class='table table-condensed'>
+        <thead title="These are your track search results. When you start to enter track information, this section will update with similar tracks that are already in our database.">
+            <tr>
+                <th>Artist</th>
+                <th>Title</th>
+                <th>Album</th>
+                <th>Label</th>
+                <th>Request</th>
+                <th>Vinyl</th>
+                <th>New</th>
+                <th>Rotation</th>
+                <th></th>
+            </tr>
+        </thead>
+    </table>
+
     <div class="row-table trackman-search-results">
         <table class='table table-condensed table-striped table-hover' id="search">
-            <thead title="These are your track search results. When you start to enter track information, this section will update with similar tracks that are already in our database.">
-                <tr>
-                    <th>Artist</th>
-                    <th>Title</th>
-                    <th>Album</th>
-                    <th>Label</th>
-                    <th>Request</th>
-                    <th>Vinyl</th>
-                    <th>New</th>
-                    <th>Rotation</th>
-                    <th></th>
-                </tr>
-            </thead>
             <tbody>
             </tbody>
         </table>
@@ -305,6 +315,6 @@
 {% endblock %}
 {% block js %}
 {{ super() }}
-<script src="{{ url_for('static', filename='js/trackman/trackman.js', v=9) }}"></script>
+<script src="{{ url_for('static', filename='js/trackman/trackman.js', v=10) }}"></script>
 <script src="{{ url_for('trackman_private.log_js', setid=djset.id) }}"></script>
 {% endblock %}


### PR DESCRIPTION
Immediately on page load and on window resize, adjust the size of the
Trackman panels to fit the window. Table headers are now also pinned to
the top of the panel to make it obvious what each column is for.