### PR TITLE
Add "public" Trackman API and use it where logical

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -2,6 +2,7 @@ bleach
 celery
 click
 Flask
+Flask-Caching
 Flask-Migrate
 flask-oidc
 Flask-RESTful

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,13 +14,14 @@ celery==4.0.2
 certifi==2017.4.17        # via requests
 chardet==3.0.4            # via requests
 click==6.7
+flask-caching==1.3.2
 flask-migrate==2.0.4
 flask-oidc==1.1.1
 flask-restful==0.3.6
 flask-script==2.0.5       # via flask-migrate
-flask-sqlalchemy==2.2     # via flask-migrate
+flask-sqlalchemy==2.2
 flask-wtf==0.14.2
-flask==0.12.2             # via flask-migrate, flask-oidc, flask-restful, flask-script, flask-sqlalchemy, flask-wtf
+flask==0.12.2
 html5lib==0.999999999     # via bleach
 httplib2==0.10.3          # via oauth2client
 humanize==0.5.1
@@ -53,5 +54,5 @@ unidecode==0.4.21
 urllib3==1.21.1           # via requests
 vine==1.1.3               # via amqp
 webencodings==0.5.1       # via html5lib
-werkzeug==0.12.2          # via flask
+werkzeug==0.12.2          # via flask, flask-caching
 wtforms==2.1              # via flask-wtf

--- a/wuvt/__init__.py
+++ b/wuvt/__init__.py
@@ -172,6 +172,14 @@ def init_app():
     app.register_blueprint(trackman.bp)
     app.register_blueprint(trackman.private_bp, url_prefix='/trackman')
     app.register_blueprint(trackman.api_bp, url_prefix='/trackman/api')
+    trackman.playlists_cache.init_app(app, config={
+        'CACHE_TYPE': "redis",
+        'CACHE_REDIS_URL': app.config['REDIS_URL'],
+    })
+    trackman.charts_cache.init_app(app, config={
+        'CACHE_TYPE': "redis",
+        'CACHE_REDIS_URL': app.config['REDIS_URL'],
+    })
 
     from wuvt import cli
     from wuvt import models

--- a/wuvt/defaults.py
+++ b/wuvt/defaults.py
@@ -2,7 +2,7 @@ DEBUG = False
 # SESSION_COOKIE_SECURE = True
 
 SQLALCHEMY_TRACK_MODIFICATIONS = False
-REDIS_URL = 'redis://localhost:6379'
+REDIS_URL = 'redis://localhost:6379/0'
 
 POSTS_PER_PAGE = 5
 ARTISTS_PER_PAGE = 500

--- a/wuvt/templates/chart_macros.html
+++ b/wuvt/templates/chart_macros.html
@@ -1,7 +1,4 @@
 {% macro render_chart_albums(results) %}
-{% set ranking = 0 %}
-{% set last_spins = -1 %}
-{% set increment = 1 %}
 <table class="tracklist tracklist-ranked chart">
     <thead>
         <th></th>
@@ -10,14 +7,7 @@
         <th class="text-right">Spins</th>
     </thead>
     <tbody>
-    {% for artist, album, spins in results %}
-        {% if spins == last_spins %}
-            {% set increment = increment + 1 %}
-        {% else %}
-            {% set last_spins = spins %}
-            {% set ranking = ranking + increment %}
-            {% set increment = 1 %}
-        {% endif %}
+    {% for artist, album, spins, ranking in results %}
         <tr>
             <td>{{ ranking }}</td>
             <td>{{ artist }}</td>
@@ -30,9 +20,6 @@
 {% endmacro %}
 
 {% macro render_chart_artists(results) %}
-{% set ranking = 0 %}
-{% set last_spins = -1 %}
-{% set increment = 1 %}
 <table class="tracklist tracklist-ranked chart">
     <thead>
         <th></th>
@@ -40,14 +27,7 @@
         <th class="text-right">Spins</th>
     </thead>
     <tbody>
-    {% for artist, spins in results %}
-        {% if spins == last_spins %}
-            {% set increment = increment + 1 %}
-        {% else %}
-            {% set last_spins = spins %}
-            {% set ranking = ranking + increment %}
-            {% set increment = 1 %}
-        {% endif %}
+    {% for artist, spins, ranking in results %}
         <tr>
             <td>{{ ranking }}</td>
             <td>{{ artist }}</td>
@@ -59,9 +39,6 @@
 {% endmacro %}
 
 {% macro render_chart_tracks(results) %}
-{% set ranking = 0 %}
-{% set last_spins = -1 %}
-{% set increment = 1 %}
 <table class="tracklist tracklist-ranked chart">
     <thead>
         <th></th>
@@ -71,14 +48,7 @@
         <th class="text-right">Spins</th>
     </thead>
     <tbody>
-    {% for track, spins in results %}
-        {% if spins == last_spins %}
-            {% set increment = increment + 1 %}
-        {% else %}
-            {% set last_spins = spins %}
-            {% set ranking = ranking + increment %}
-            {% set increment = 1 %}
-        {% endif %}
+    {% for track, spins, ranking in results %}
         <tr>
             <td>{{ ranking }}</td>
             <td>{{ track.artist }}</td>
@@ -92,9 +62,6 @@
 {% endmacro %}
 
 {% macro render_chart_dj(results) %}
-{% set ranking = 0 %}
-{% set last_spins = -1 %}
-{% set increment = 1 %}
 <table class="tracklist tracklist-ranked chart">
     <thead>
         <th></th>
@@ -102,14 +69,7 @@
         <th class="text-right">Spins</th>
     </thead>
     <tbody>
-    {% for dj, spins in results %}
-        {% if spins == last_spins %}
-            {% set increment = increment + 1 %}
-        {% else %}
-            {% set last_spins = spins %}
-            {% set ranking = ranking + increment %}
-            {% set increment = 1 %}
-        {% endif %}
+    {% for dj, spins, ranking in results %}
         <tr>
             <td>{{ ranking }}</td>
             <td><a href="{{ url_for('trackman.playlists_dj_sets', dj_id=dj.id) }}">{{ dj.airname }}</a></td>

--- a/wuvt/trackman/__init__.py
+++ b/wuvt/trackman/__init__.py
@@ -2,7 +2,6 @@ from flask import Blueprint
 
 bp = Blueprint('trackman', __name__)
 private_bp = Blueprint('trackman_private', __name__)
-api_bp = Blueprint('trackman_api', __name__)
 
 from .cache import ResourceCache
 playlists_cache = ResourceCache(config={
@@ -14,5 +13,5 @@ charts_cache = ResourceCache(config={
 })
 
 from . import admin_views, cli, views
-from .api import api
+from .api import api, api_bp
 from .views import trackinfo

--- a/wuvt/trackman/__init__.py
+++ b/wuvt/trackman/__init__.py
@@ -4,6 +4,15 @@ bp = Blueprint('trackman', __name__)
 private_bp = Blueprint('trackman_private', __name__)
 api_bp = Blueprint('trackman_api', __name__)
 
+from .cache import ResourceCache
+playlists_cache = ResourceCache(config={
+    'CACHE_KEY_PREFIX': "trackman_playlists_",
+})
+charts_cache = ResourceCache(config={
+    'CACHE_DEFAULT_TIMEOUT': 14400,
+    'CACHE_KEY_PREFIX': "trackman_charts_",
+})
+
 from . import admin_views, cli, views
 from .api import api
 from .views import trackinfo

--- a/wuvt/trackman/admin_views.py
+++ b/wuvt/trackman/admin_views.py
@@ -4,11 +4,11 @@ from flask import current_app, flash, json, jsonify, render_template, \
 import datetime
 
 from .. import db, redis_conn
-from ..view_utils import local_only, sse_response
 from . import private_bp, mail
 from .forms import DJRegisterForm, DJReactivateForm
 from .lib import enable_automation, check_onair
 from .models import DJ, DJSet, TrackLog, Rotation
+from .view_utils import local_only, sse_response
 
 
 @private_bp.route('/', methods=['GET', 'POST'])

--- a/wuvt/trackman/api/__init__.py
+++ b/wuvt/trackman/api/__init__.py
@@ -10,6 +10,11 @@ from .v1.djset import DJSet, DJSetList
 from .v1.track import Track, TrackReport, TrackSearch, TrackAutoComplete, \
     TrackList
 from .v1.tracklog import TrackLog, TrackLogList
+from .v1.charts import Charts, AlbumCharts, DJAlbumCharts, ArtistCharts, \
+    DJArtistCharts, TrackCharts, DJTrackCharts, DJSpinCharts, DJVinylSpinCharts
+from .v1.playlists import NowPlaying, Last15Tracks, LatestTrack, \
+    PlaylistsByDay, PlaylistDJs, PlaylistAllDJs, PlaylistsByDJ, Playlist, \
+    PlaylistTrack
 
 
 api = Api(api_bp)
@@ -27,6 +32,37 @@ api.add_resource(TrackLogList, '/tracklog')
 api.add_resource(AutologoutControl, '/autologout')
 api.add_resource(AirLog, '/airlog/edit/<int:airlog_id>')
 api.add_resource(AirLogList, '/airlog')
+api.add_resource(Charts, '/charts')
+api.add_resource(AlbumCharts,
+                 '/charts/albums',
+                 '/charts/albums/<string:period>',
+                 '/charts/albums/<string:period>/<int:year>',
+                 '/charts/albums/<string:period>/<int:year>/<int:month>')
+api.add_resource(DJAlbumCharts, '/charts/dj/<int:dj_id>/albums')
+api.add_resource(ArtistCharts,
+                 '/charts/artists',
+                 '/charts/artists/<string:period>',
+                 '/charts/artists/<string:period>/<int:year>',
+                 '/charts/artists/<string:period>/<int:year>/<int:month>')
+api.add_resource(DJArtistCharts, '/charts/dj/<int:dj_id>/artists')
+api.add_resource(TrackCharts,
+                 '/charts/tracks',
+                 '/charts/tracks/<string:period>',
+                 '/charts/tracks/<string:period>/<int:year>',
+                 '/charts/tracks/<string:period>/<int:year>/<int:month>')
+api.add_resource(DJTrackCharts, '/charts/dj/<int:dj_id>/tracks')
+api.add_resource(DJSpinCharts, '/charts/dj/spins')
+api.add_resource(DJVinylSpinCharts, '/charts/dj/vinyl_spins')
+api.add_resource(NowPlaying, '/now_playing')
+api.add_resource(Last15Tracks, '/playlists/last15')
+api.add_resource(LatestTrack, '/playlists/latest_track')
+api.add_resource(PlaylistsByDay,
+                 '/playlists/date/<int:year>/<int:month>/<int:day>')
+api.add_resource(PlaylistDJs, '/playlists/dj')
+api.add_resource(PlaylistAllDJs, '/playlists/dj/all')
+api.add_resource(PlaylistsByDJ, '/playlists/dj/<int:dj_id>')
+api.add_resource(Playlist, '/playlists/set/<int:set_id>')
+api.add_resource(PlaylistTrack, '/playlists/track/<int:track_id>')
 
 
 @api.representation('application/json')

--- a/wuvt/trackman/api/__init__.py
+++ b/wuvt/trackman/api/__init__.py
@@ -1,7 +1,6 @@
-from flask import json, make_response
+from flask import Blueprint, json, make_response
 from flask_restful import Api
 
-from wuvt.trackman import api_bp
 from .v1.airlog import AirLog, AirLogList
 from .v1.autologout import AutologoutControl
 from .v1.automation import AutomationLog
@@ -17,6 +16,7 @@ from .v1.playlists import NowPlaying, Last15Tracks, LatestTrack, \
     PlaylistTrack
 
 
+api_bp = Blueprint('trackman_api', __name__)
 api = Api(api_bp)
 api.add_resource(AutomationLog, '/automation/log')
 api.add_resource(DJ, '/dj/<int:djset_id>')

--- a/wuvt/trackman/api/v1/airlog.py
+++ b/wuvt/trackman/api/v1/airlog.py
@@ -2,7 +2,7 @@ import dateutil.parser
 from flask import session
 from flask_restful import abort
 from wuvt import db
-from wuvt.trackman import models
+from wuvt.trackman import models, playlists_cache
 from wuvt.trackman.forms import AirLogForm, AirLogEditForm
 from .base import TrackmanOnAirResource
 
@@ -45,6 +45,7 @@ class AirLog(TrackmanOnAirResource):
             db.session.rollback()
             raise
 
+        playlists_cache.clear()
         return {'success': True}
 
     def post(self, airlog_id):
@@ -112,6 +113,7 @@ class AirLog(TrackmanOnAirResource):
             db.session.rollback()
             raise
 
+        playlists_cache.clear()
         return {'success': True}
 
 
@@ -168,6 +170,7 @@ class AirLogList(TrackmanOnAirResource):
             db.session.rollback()
             raise
 
+        playlists_cache.clear()
         return {
             'success': True,
             'airlog_id': airlog.id,

--- a/wuvt/trackman/api/v1/base.py
+++ b/wuvt/trackman/api/v1/base.py
@@ -1,6 +1,7 @@
 from flask_restful import Resource
 from wuvt import csrf
 from wuvt.view_utils import ajax_only, local_only
+from wuvt.trackman import playlists_cache, charts_cache
 from wuvt.trackman.view_utils import dj_interact, require_dj_session, \
     require_onair
 
@@ -18,3 +19,11 @@ class TrackmanOnAirResource(TrackmanResource):
 
 class TrackmanStudioResource(TrackmanResource):
     method_decorators = [local_only, ajax_only, dj_interact]
+
+
+class PlaylistResource(Resource):
+    method_decorators = {'get': [playlists_cache.memoize()]}
+
+
+class ChartResource(Resource):
+    method_decorators = {'get': [charts_cache.memoize()]}

--- a/wuvt/trackman/api/v1/charts.py
+++ b/wuvt/trackman/api/v1/charts.py
@@ -1,0 +1,179 @@
+from flask_restful import abort, Resource
+from wuvt import db
+from wuvt.trackman import charts
+from wuvt.trackman.models import DJ, Track, TrackLog
+from .base import ChartResource
+
+
+class Charts(Resource):
+    def get(self):
+        return {
+            'albums': "Top albums",
+            'artists': "Top artists",
+            'tracks': "Top tracks",
+        }
+
+
+class AlbumCharts(ChartResource):
+    def get(self, period=None, year=None, month=None):
+        try:
+            start, end = charts.get_range(period, year, month)
+        except ValueError:
+            abort(404)
+
+        results = charts.get(
+            'albums_{0}_{1}'.format(start, end),
+            Track.query.with_entities(
+                Track.artist, Track.album, db.func.count(TrackLog.id)).
+            join(TrackLog).filter(db.and_(
+                TrackLog.dj_id > 1,
+                TrackLog.played >= start,
+                TrackLog.played <= end)).
+            group_by(Track.artist, Track.album).
+            order_by(db.func.count(TrackLog.id).desc()))
+
+        return {
+            'start': start,
+            'end': end,
+            'results': [(x[0], x[1], x[2], x[3]) for x in results],
+        }
+
+
+class DJAlbumCharts(ChartResource):
+    def get(self, dj_id):
+        dj = DJ.query.get_or_404(dj_id)
+        results = charts.get(
+            'albums_dj_{}'.format(dj_id),
+            Track.query.with_entities(
+                Track.artist, Track.album, db.func.count(TrackLog.id)).
+            join(TrackLog).filter(TrackLog.dj_id == dj.id).
+            group_by(Track.artist, Track.album).
+            order_by(db.func.count(TrackLog.id).desc()))
+
+        return {
+            'dj': dj.serialize(),
+            'results': [(x[0], x[1], x[2], x[3]) for x in results],
+        }
+
+
+class ArtistCharts(ChartResource):
+    def get(self, period=None, year=None, month=None):
+        try:
+            start, end = charts.get_range(period, year, month)
+        except ValueError:
+            abort(404)
+
+        results = charts.get(
+            'artists_{0}_{1}'.format(start, end),
+            Track.query.with_entities(Track.artist, db.func.count(TrackLog.id)).
+            join(TrackLog).filter(db.and_(
+                TrackLog.dj_id > 1,
+                TrackLog.played >= start,
+                TrackLog.played <= end)).
+            group_by(Track.artist).
+            order_by(db.func.count(TrackLog.id).desc()))
+
+        return {
+            'start': start,
+            'end': end,
+            'results': [(x[0], x[1], x[2]) for x in results],
+        }
+
+
+class DJArtistCharts(ChartResource):
+    def get(self, dj_id):
+        dj = DJ.query.get_or_404(dj_id)
+        results = charts.get(
+            'artists_dj_{}'.format(dj_id),
+            Track.query.with_entities(Track.artist, db.func.count(TrackLog.id)).
+            join(TrackLog).filter(TrackLog.dj_id == dj.id).
+            group_by(Track.artist).
+            order_by(db.func.count(TrackLog.id).desc()))
+
+        return {
+            'dj': dj.serialize(),
+            'results': [(x[0], x[1], x[2]) for x in results],
+        }
+
+
+class TrackCharts(ChartResource):
+    def get(self, period=None, year=None, month=None):
+        try:
+            start, end = charts.get_range(period, year, month)
+        except ValueError:
+            abort(404)
+
+        subquery = TrackLog.query.\
+            with_entities(TrackLog.track_id,
+                          db.func.count(TrackLog.id).label('count')).\
+            filter(TrackLog.dj_id > 1,
+                   TrackLog.played >= start,
+                   TrackLog.played <= end).\
+            group_by(TrackLog.track_id).subquery()
+        results = charts.get(
+            'tracks_{start}_{end}'.format(start=start, end=end),
+            Track.query.with_entities(Track, subquery.c.count).
+            join(subquery).order_by(db.desc(subquery.c.count)))
+
+        return {
+            'start': start,
+            'end': end,
+            'results': [(x[0].serialize(), x[1], x[2]) for x in results],
+        }
+
+
+class DJTrackCharts(ChartResource):
+    def get(self, dj_id):
+        dj = DJ.query.get_or_404(dj_id)
+
+        subquery = TrackLog.query.\
+            with_entities(TrackLog.track_id,
+                          db.func.count(TrackLog.id).label('count')).\
+            filter(TrackLog.dj_id == dj.id).\
+            group_by(TrackLog.track_id).subquery()
+        results = charts.get(
+            'tracks_dj_{}'.format(dj_id),
+            Track.query.with_entities(Track, subquery.c.count).
+            join(subquery).order_by(db.desc(subquery.c.count)))
+
+        return {
+            'dj': dj.serialize(),
+            'results': [(x[0].serialize(), x[1], x[2]) for x in results],
+        }
+
+
+class DJSpinCharts(ChartResource):
+    def get(self):
+        subquery = TrackLog.query.\
+            with_entities(TrackLog.dj_id,
+                          db.func.count(TrackLog.id).label('count')).\
+            group_by(TrackLog.dj_id).subquery()
+
+        results = charts.get(
+            'dj_spins',
+            DJ.query.with_entities(DJ, subquery.c.count).
+            join(subquery).filter(DJ.visible == True).
+            order_by(db.desc(subquery.c.count)))
+
+        return {
+            'results': [(x[0].serialize(), x[1], x[2]) for x in results],
+        }
+
+
+class DJVinylSpinCharts(ChartResource):
+    def get(self):
+        subquery = TrackLog.query.\
+            with_entities(TrackLog.dj_id,
+                          db.func.count(TrackLog.id).label('count')).\
+            filter(TrackLog.vinyl == True).\
+            group_by(TrackLog.dj_id).subquery()
+
+        results = charts.get(
+            'dj_vinyl_spins',
+            DJ.query.with_entities(DJ, subquery.c.count).
+            join(subquery).filter(DJ.visible == True).
+            order_by(db.desc(subquery.c.count)))
+
+        return {
+            'results': [(x[0].serialize(), x[1], x[2]) for x in results],
+        }

--- a/wuvt/trackman/api/v1/djset.py
+++ b/wuvt/trackman/api/v1/djset.py
@@ -75,9 +75,12 @@ class DJSetList(TrackmanResource):
         """
         dj_id = session.get('dj_id', None)
         if dj_id is None:
-            abort(404)
+            abort(403)
 
-        dj = models.DJ.query.get_or_404(dj_id)
+        dj = models.DJ.query.get(dj_id)
+        if dj is None or dj.phone is None or dj.email is None:
+            abort(403,
+                  message="You must complete your DJ profile to continue.")
 
         disable_automation()
 

--- a/wuvt/trackman/api/v1/playlists.py
+++ b/wuvt/trackman/api/v1/playlists.py
@@ -8,12 +8,32 @@ from .base import PlaylistResource
 
 class NowPlaying(PlaylistResource):
     def get(self):
+        """
+        Retrieve information about what is currently playing.
+        ---
+        operationId: getNowPlaying
+        tags:
+        - trackman
+        - playlists
+        - tracklog
+        - track
+        """
         tracklog = TrackLog.query.order_by(db.desc(TrackLog.id)).first()
         return tracklog.api_serialize()
 
 
 class Last15Tracks(PlaylistResource):
     def get(self):
+        """
+        Retrieve information about the last 15 tracks that were played.
+        ---
+        operationId: getLast15
+        tags:
+        - trackman
+        - playlists
+        - tracklog
+        - track
+        """
         tracks = TrackLog.query.order_by(db.desc(TrackLog.id)).limit(15).all()
         return {
             'tracks': [t.api_serialize() for t in tracks],
@@ -22,11 +42,48 @@ class Last15Tracks(PlaylistResource):
 
 class LatestTrack(PlaylistResource):
     def get(self):
+        """
+        Retrieve information about what is currently playing in the old format.
+        ---
+        operationId: getLatestTrack
+        tags:
+        - trackman
+        - playlists
+        - tracklog
+        - track
+        """
         return serialize_trackinfo(get_current_tracklog())
 
 
 class PlaylistsByDay(PlaylistResource):
     def get(self, year, month, day):
+        """
+        Get a list of playlists played on a particular day.
+        ---
+        operationId: getPlaylistsByDay
+        tags:
+        - trackman
+        - track
+        parameters:
+        - in: path
+          name: year
+          type: integer
+          required: true
+          description: Year
+        - in: path
+          name: month
+          type: integer
+          required: true
+          description: Month
+        - in: path
+          name: day
+          type: integer
+          required: true
+          description: Day of month
+        responses:
+          404:
+            description: No playlists found
+        """
         dtstart = datetime.datetime(year, month, day, 0, 0, 0)
         dtend = datetime.datetime(year, month, day, 23, 59, 59)
         sets = DJSet.query.\
@@ -46,6 +103,15 @@ class PlaylistsByDay(PlaylistResource):
 
 class PlaylistDJs(PlaylistResource):
     def get(self):
+        """
+        List DJs who have played something recently.
+        ---
+        operationId: getPlaylistDJs
+        tags:
+        - trackman
+        - playlists
+        - dj
+        """
         djs = DJ.query.order_by(DJ.airname).filter(DJ.visible == True)
         return {
             'djs': [dj.serialize() for dj in djs],
@@ -54,6 +120,15 @@ class PlaylistDJs(PlaylistResource):
 
 class PlaylistAllDJs(PlaylistResource):
     def get(self):
+        """
+        List all DJs, even those that haven't played anything in a while.
+        ---
+        operationId: getPlaylistAllDJs
+        tags:
+        - trackman
+        - playlists
+        - dj
+        """
         djs = DJ.query.order_by(DJ.airname).all()
         return {
             'djs': [dj.serialize() for dj in djs],
@@ -62,6 +137,23 @@ class PlaylistAllDJs(PlaylistResource):
 
 class PlaylistsByDJ(PlaylistResource):
     def get(self, dj_id):
+        """
+        Get a list of playlists played by a particular DJ.
+        ---
+        operationId: getPlaylistsByDJ
+        tags:
+        - trackman
+        - track
+        parameters:
+        - in: path
+          name: dj_id
+          type: integer
+          required: true
+          description: The ID of a DJ
+        responses:
+          404:
+            description: DJ not found
+        """
         dj = DJ.query.get_or_404(dj_id)
         sets = DJSet.query.filter(DJSet.dj_id == dj_id).order_by(
             DJSet.dtstart).all()
@@ -73,6 +165,23 @@ class PlaylistsByDJ(PlaylistResource):
 
 class Playlist(PlaylistResource):
     def get(self, set_id):
+        """
+        Get a list of tracks and archive links for a playlist.
+        ---
+        operationId: getPlaylist
+        tags:
+        - trackman
+        - track
+        parameters:
+        - in: path
+          name: set_id
+          type: integer
+          required: true
+          description: The ID of an existing playlist
+        responses:
+          404:
+            description: Playlist not found
+        """
         djset = DJSet.query.get_or_404(set_id)
         tracks = TrackLog.query.filter(TrackLog.djset_id == djset.id).order_by(
             TrackLog.played).all()
@@ -87,6 +196,23 @@ class Playlist(PlaylistResource):
 
 class PlaylistTrack(PlaylistResource):
     def get(self, track_id):
+        """
+        Get information about a Track.
+        ---
+        operationId: getPlaylistTrack
+        tags:
+        - trackman
+        - track
+        parameters:
+        - in: path
+          name: track_id
+          type: integer
+          required: true
+          description: The ID of an existing Track
+        responses:
+          404:
+            description: Track not found
+        """
         track = Track.query.get_or_404(track_id)
         tracklogs = TrackLog.query.filter(TrackLog.track_id == track.id).\
             order_by(TrackLog.played).all()

--- a/wuvt/trackman/api/v1/playlists.py
+++ b/wuvt/trackman/api/v1/playlists.py
@@ -1,0 +1,96 @@
+import datetime
+from wuvt import db
+from wuvt.trackman.lib import get_current_tracklog, serialize_trackinfo
+from wuvt.trackman.models import DJ, DJSet, Track, TrackLog
+from wuvt.trackman.view_utils import list_archives
+from .base import PlaylistResource
+
+
+class NowPlaying(PlaylistResource):
+    def get(self):
+        tracklog = TrackLog.query.order_by(db.desc(TrackLog.id)).first()
+        return tracklog.api_serialize()
+
+
+class Last15Tracks(PlaylistResource):
+    def get(self):
+        tracks = TrackLog.query.order_by(db.desc(TrackLog.id)).limit(15).all()
+        return {
+            'tracks': [t.api_serialize() for t in tracks],
+        }
+
+
+class LatestTrack(PlaylistResource):
+    def get(self):
+        return serialize_trackinfo(get_current_tracklog())
+
+
+class PlaylistsByDay(PlaylistResource):
+    def get(self, year, month, day):
+        dtstart = datetime.datetime(year, month, day, 0, 0, 0)
+        dtend = datetime.datetime(year, month, day, 23, 59, 59)
+        sets = DJSet.query.\
+            filter(DJSet.dtstart >= dtstart, DJSet.dtstart <= dtend).\
+            all()
+
+        status_code = 200
+        if len(sets) <= 0:
+            # return 404 if no playlists found
+            status_code = 404
+
+        return {
+            'dtstart': dtstart,
+            'sets': [s.serialize() for s in sets],
+        }, status_code
+
+
+class PlaylistDJs(PlaylistResource):
+    def get(self):
+        djs = DJ.query.order_by(DJ.airname).filter(DJ.visible == True)
+        return {
+            'djs': [dj.serialize() for dj in djs],
+        }
+
+
+class PlaylistAllDJs(PlaylistResource):
+    def get(self):
+        djs = DJ.query.order_by(DJ.airname).all()
+        return {
+            'djs': [dj.serialize() for dj in djs],
+        }
+
+
+class PlaylistsByDJ(PlaylistResource):
+    def get(self, dj_id):
+        dj = DJ.query.get_or_404(dj_id)
+        sets = DJSet.query.filter(DJSet.dj_id == dj_id).order_by(
+            DJSet.dtstart).all()
+        return {
+            'dj': dj.serialize(),
+            'sets': [s.serialize() for s in sets],
+        }
+
+
+class Playlist(PlaylistResource):
+    def get(self, set_id):
+        djset = DJSet.query.get_or_404(set_id)
+        tracks = TrackLog.query.filter(TrackLog.djset_id == djset.id).order_by(
+            TrackLog.played).all()
+
+        data = djset.serialize()
+        data.update({
+            'archives': [list(a) for a in list_archives(djset)],
+            'tracks': [t.api_serialize() for t in tracks],
+        })
+        return data
+
+
+class PlaylistTrack(PlaylistResource):
+    def get(self, track_id):
+        track = Track.query.get_or_404(track_id)
+        tracklogs = TrackLog.query.filter(TrackLog.track_id == track.id).\
+            order_by(TrackLog.played).all()
+
+        data = track.serialize()
+        data['plays'] = [tl.api_serialize() for tl in tracklogs]
+        return data

--- a/wuvt/trackman/api/v1/playlists.py
+++ b/wuvt/trackman/api/v1/playlists.py
@@ -91,6 +91,6 @@ class PlaylistTrack(PlaylistResource):
         tracklogs = TrackLog.query.filter(TrackLog.track_id == track.id).\
             order_by(TrackLog.played).all()
 
-        data = track.serialize()
+        data = track.api_serialize()
         data['plays'] = [tl.api_serialize() for tl in tracklogs]
         return data

--- a/wuvt/trackman/cache.py
+++ b/wuvt/trackman/cache.py
@@ -69,7 +69,8 @@ class ResourceCache(Cache):
                 # We specifically skip these self/cls cases since flask-restful
                 # does not provide these to us anyway:
                 # https://github.com/flask-restful/flask-restful/issues/585
-                arg_num += 1
+                # If that ever changes, this should be updated.
+                #arg_num += 1
                 continue
             elif arg_names[i] in kwargs:
                 arg = kwargs[arg_names[i]]

--- a/wuvt/trackman/cache.py
+++ b/wuvt/trackman/cache.py
@@ -1,0 +1,91 @@
+# Workarounds to allow flask-caching to work with flask-restful
+# Original code:
+#   Copyright (c) 2010 by Thadeus Burgess.
+#   Copyright (c) 2016 by Peter Justin.
+
+from collections import OrderedDict
+from flask_caching import Cache, get_arg_names, get_arg_default, iteritems, \
+    function_namespace
+
+
+class ResourceCache(Cache):
+    def _memoize_version(self, f, args=None, reset=False, delete=False,
+                         timeout=None, forced_update=False):
+        """Updates the hash version associated with a memoized function or
+        method.
+        """
+        # We don't care about which instance we're using for this
+        fname, _ = function_namespace(f, args=args)
+        version_key = self._memvname(fname)
+        fetch_keys = [version_key]
+
+        # Only delete the per-instance version key or per-function version
+        # key but not both.
+        if delete:
+            self.cache.delete_many(fetch_keys[-1])
+            return fname, None
+
+        version_data_list = list(self.cache.get_many(*fetch_keys))
+        dirty = False
+
+        if callable(forced_update) and forced_update() is True:
+            # Mark key as dirty to update its TTL
+            dirty = True
+
+        if version_data_list[0] is None:
+            version_data_list[0] = self._memoize_make_version_hash()
+            dirty = True
+
+        # Only reset the per-instance version or the per-function version
+        # but not both.
+        if reset:
+            fetch_keys = fetch_keys[-1:]
+            version_data_list = [self._memoize_make_version_hash()]
+            dirty = True
+
+        if dirty:
+            self.cache.set_many(dict(zip(fetch_keys, version_data_list)),
+                                timeout=timeout)
+
+        return fname, ''.join(version_data_list)
+
+    def _memoize_kwargs_to_args(self, f, *args, **kwargs):
+        #: Inspect the arguments to the function
+        #: This allows the memoization to be the same
+        #: whether the function was called with
+        #: 1, b=2 is equivalent to a=1, b=2, etc.
+        new_args = []
+        arg_num = 0
+
+        # If the function uses VAR_KEYWORD type of parameters,
+        # we need to pass these further
+        kw_keys_remaining = list(kwargs.keys())
+        arg_names = get_arg_names(f)
+        args_len = len(arg_names)
+
+        for i in range(args_len):
+            arg_default = get_arg_default(f, i)
+            if i == 0 and arg_names[i] in ('self', 'cls'):
+                # We specifically skip these self/cls cases since flask-restful
+                # does not provide these to us anyway:
+                # https://github.com/flask-restful/flask-restful/issues/585
+                arg_num += 1
+                continue
+            elif arg_names[i] in kwargs:
+                arg = kwargs[arg_names[i]]
+                kw_keys_remaining.pop(kw_keys_remaining.index(arg_names[i]))
+            elif arg_num < len(args):
+                arg = args[arg_num]
+                arg_num += 1
+            elif arg_default:
+                arg = arg_default
+                arg_num += 1
+            else:
+                arg = None
+                arg_num += 1
+
+            new_args.append(arg)
+
+        return tuple(new_args), OrderedDict(sorted(
+            (k, v) for k, v in iteritems(kwargs) if k in kw_keys_remaining
+        ))

--- a/wuvt/trackman/models.py
+++ b/wuvt/trackman/models.py
@@ -165,6 +165,29 @@ class TrackLog(db.Model):
             'listeners': self.listeners,
         }
 
+    def api_serialize(self):
+        if self.rotation is not None:
+            rotation = self.rotation.serialize()
+        else:
+            rotation = None
+
+        return {
+            'id': self.id,
+            'track_id': self.track_id,
+            'track': self.track.serialize(),
+            'played': self.played,
+            'djset_id': self.djset_id,
+            'djset': self.djset.serialize(),
+            'dj_id': self.dj_id,
+            'dj': self.dj.serialize(),
+            'request': self.request,
+            'vinyl': self.vinyl,
+            'new': self.new,
+            'rotation_id': self.rotation_id,
+            'rotation': rotation,
+            'listeners': self.listeners,
+        }
+
 
 class Track(db.Model):
     __tablename__ = "track"

--- a/wuvt/trackman/models.py
+++ b/wuvt/trackman/models.py
@@ -152,7 +152,7 @@ class TrackLog(db.Model):
         return {
             'tracklog_id': self.id,
             'track_id': self.track_id,
-            'track': Track.query.get(self.track_id).serialize(),
+            'track': self.track.serialize(),
             'played': self.played,
             'djset': self.djset_id,
             'dj_id': self.dj_id,
@@ -174,7 +174,7 @@ class TrackLog(db.Model):
         return {
             'id': self.id,
             'track_id': self.track_id,
-            'track': self.track.serialize(),
+            'track': self.track.api_serialize(),
             'played': self.played,
             'djset_id': self.djset_id,
             'djset': self.djset.serialize(),
@@ -217,6 +217,20 @@ class Track(db.Model):
             'album': self.album,
             'label': self.label,
             'added': str(self.added),
+            'artist_mbid': self.artist_mbid,
+            'recording_mbid': self.recording_mbid,
+            'release_mbid': self.release_mbid,
+            'releasegroup_mbid': self.releasegroup_mbid,
+        }
+
+    def api_serialize(self):
+        return {
+            'id': self.id,
+            'title': self.title,
+            'artist': self.artist,
+            'album': self.album,
+            'label': self.label,
+            'added': self.added,
             'artist_mbid': self.artist_mbid,
             'recording_mbid': self.recording_mbid,
             'release_mbid': self.release_mbid,

--- a/wuvt/trackman/view_utils.py
+++ b/wuvt/trackman/view_utils.py
@@ -5,6 +5,7 @@ from flask_restful import abort, Resource
 from functools import wraps
 from urlparse import urljoin
 from .lib import perdelta, renew_dj_lease, check_onair
+from ..view_utils import local_only, sse_response
 
 
 def dj_interact(f):

--- a/wuvt/trackman/view_utils.py
+++ b/wuvt/trackman/view_utils.py
@@ -81,4 +81,7 @@ def call_api(resource, method, *args, **kwargs):
     for decorator in decorators:
         meth = decorator(meth)
 
+    # The instance is not included in this call to match flask_restful's
+    # behavior. If that ever changes, this should be updated.
+    # See https://github.com/flask-restful/flask-restful/issues/585
     return meth(*args, **kwargs)

--- a/wuvt/trackman/view_utils.py
+++ b/wuvt/trackman/view_utils.py
@@ -1,6 +1,7 @@
+from collections import Mapping
 from datetime import timedelta
 from flask import current_app, request, session
-from flask_restful import abort
+from flask_restful import abort, Resource
 from functools import wraps
 from urlparse import urljoin
 from .lib import perdelta, renew_dj_lease, check_onair
@@ -58,3 +59,25 @@ def require_onair(f):
         else:
             return f(*args, **kwargs)
     return require_onair_wrapper
+
+
+def call_api(resource, method, *args, **kwargs):
+    if not isinstance(resource, Resource):
+        resource = resource()
+
+    # Taken from flask
+    #noinspection PyUnresolvedReferences
+    meth = getattr(resource, method.lower(), None)
+    if meth is None and method == 'HEAD':
+        meth = getattr(resource, 'get', None)
+    assert meth is not None, 'Unimplemented method %r' % method
+
+    if isinstance(resource.method_decorators, Mapping):
+        decorators = resource.method_decorators.get(method.lower(), [])
+    else:
+        decorators = resource.method_decorators
+
+    for decorator in decorators:
+        meth = decorator(meth)
+
+    return meth(*args, **kwargs)

--- a/wuvt/trackman/views.py
+++ b/wuvt/trackman/views.py
@@ -2,8 +2,6 @@
 
 from flask import abort, current_app, jsonify, render_template, redirect, \
         request, url_for, Response
-from flask_restful import Resource
-from collections import Mapping
 import datetime
 import re
 from werkzeug.contrib.atom import AtomFeed
@@ -12,30 +10,8 @@ from .. import db
 from ..view_utils import sse_response
 from . import bp
 from .models import DJSet, Track, TrackLog
-from .view_utils import make_external, list_archives
+from .view_utils import call_api, make_external, list_archives
 from .api.v1 import charts, playlists
-
-
-def call_api(resource, method, *args, **kwargs):
-    if not isinstance(resource, Resource):
-        resource = resource()
-
-    # Taken from flask
-    #noinspection PyUnresolvedReferences
-    meth = getattr(resource, method.lower(), None)
-    if meth is None and method == 'HEAD':
-        meth = getattr(resource, 'get', None)
-    assert meth is not None, 'Unimplemented method %r' % method
-
-    if isinstance(resource.method_decorators, Mapping):
-        decorators = resource.method_decorators.get(method.lower(), [])
-    else:
-        decorators = resource.method_decorators
-
-    for decorator in decorators:
-        meth = decorator(meth)
-
-    return meth(*args, **kwargs)
 
 
 def trackinfo():

--- a/wuvt/trackman/views.py
+++ b/wuvt/trackman/views.py
@@ -7,10 +7,9 @@ import re
 from werkzeug.contrib.atom import AtomFeed
 
 from .. import db
-from ..view_utils import sse_response
 from . import bp
 from .models import DJSet, Track, TrackLog
-from .view_utils import call_api, make_external, list_archives
+from .view_utils import call_api, make_external, list_archives, sse_response
 from .api.v1 import charts, playlists
 
 


### PR DESCRIPTION
Previously, the "public" Trackman API consisted of a few endpoints that also supported JSON output in addition to HTML. Since we are already using Flask-RESTful for the DJ-facing Trackman API, it makes sense to use it to provide a more complete public API.

To simplify things and to begin caching more aggressively, we also pull in flask-caching with a special ResourceCache subclass that allows caching of API call results. This makes caching as simple as adding a decorator. The old caching functionality that was being used for charts has been removed.

To avoid duplication and to leverage the new caching functionality, the existing web interface and "v0" API calls have been converted to call the new API to retrieve data.