### PR TITLE
make notice about premiums prominent in form

### DIFF
--- a/wuvt/templates/donate/premium_form.html
+++ b/wuvt/templates/donate/premium_form.html
@@ -67,13 +67,13 @@
                 value="ship" />
             Yes, ship them to me (+${{ config.DONATE_SHIPPING_COST }}, US only)
         </label>
-        <label>
+
+        <div id="premium_fields">
+        <p>
             <b>Note:</b> we are unable to guarantee premium availability if pledges
             are made outside of Radiothon week. If you make a recurring monthly
             donation, you will only be sent premiums for the first month.
-        </label>
-
-        <div id="premium_fields">
+        </p>
         <label>
             T-Shirt Size
             <select id="id_tshirtsize" name="tshirtsize">

--- a/wuvt/templates/donate/premium_form.html
+++ b/wuvt/templates/donate/premium_form.html
@@ -67,6 +67,11 @@
                 value="ship" />
             Yes, ship them to me (+${{ config.DONATE_SHIPPING_COST }}, US only)
         </label>
+        <label>
+            <b>Note:</b> we are unable to guarantee premium availability if pledges
+            are made outside of Radiothon week. If you make a recurring monthly
+            donation, you will only be sent premiums for the first month.
+        </label>
 
         <div id="premium_fields">
         <label>


### PR DESCRIPTION
This will ensure people know that they are only getting premiums for 1 month if setting up recurring donations, and better obviate that premiums are a radiothon-only event since we can't get people to update the site.