### PR TITLE
Automation should not start so quickly when there is a DJ active but not on air

### DIFF
--- a/wuvt/trackman/admin_views.py
+++ b/wuvt/trackman/admin_views.py
@@ -4,7 +4,7 @@ from flask import current_app, flash, jsonify, render_template, \
 from .. import db, redis_conn
 from . import private_bp
 from .forms import DJRegisterForm, DJReactivateForm
-from .lib import enable_automation
+from .lib import enable_automation, renew_dj_lease
 from .models import DJ, DJSet
 from .view_utils import local_only, sse_response
 
@@ -22,6 +22,8 @@ def login():
                 ua=request.user_agent))
 
         session['dj_id'] = dj.id
+        renew_dj_lease()
+
         return redirect(url_for('.log'))
 
     automation = redis_conn.get('automation_enabled') == b"true"
@@ -55,6 +57,8 @@ def login_all():
                 ua=request.user_agent))
 
         session['dj_id'] = dj.id
+        renew_dj_lease()
+
         return redirect(url_for('.log'))
 
     automation = redis_conn.get('automation_enabled') == b"true"
@@ -105,6 +109,8 @@ or you pressed the Logout button somewhere else.
             session.pop('djset_id', None)
 
             return redirect(url_for('.login'))
+
+    renew_dj_lease()
 
     return render_template('trackman/log.html',
                            trackman_name=current_app.config['TRACKMAN_NAME'],


### PR DESCRIPTION
We made changes recently to allow DJs to access Trackman without an active DJSet (i.e. "on air") so that they won't interfere with automation. The problem that we're running into now is that automation will actually end up starting before a DJ is able to log any tracks because the DJ active timeout gets left at `NO_DJ_TIMEOUT`, which is 5 minutes in our environment. Instead, we should set it to `DJ_TIMEOUT` so that it is treated the same as if the DJ is on air.