### PR TITLE
Improve handling of expired and unusable DJSets

### DIFF
--- a/wuvt/static/css/admin.css
+++ b/wuvt/static/css/admin.css
@@ -93,7 +93,8 @@ td.row-options {
             column-count: 5;
 }
 
-.trackman-header button {
+.trackman-header form > button,
+.trackman-header .btn-group {
     margin-left: 1em;
 }
 

--- a/wuvt/static/js/trackman/trackman.js
+++ b/wuvt/static/js/trackman/trackman.js
@@ -365,7 +365,14 @@ Trackman.prototype.logTrack = function(track, callback) {
             context: this,
             type: "POST",
             success: callback,
-            error: this.handleError,
+            error: function(jqXHR, statusText, errorThrown) {
+                if(jqXHR.responseJSON['onair'] == false) {
+                    this.djsetId = null;
+                    this.logTrack(track, callback);
+                } else {
+                    inst.handleError(jqXHR, statusText, errorThrown);
+                }
+            },
         });
     } else {
         // create a new DJSet, start using it, and try again
@@ -1238,7 +1245,7 @@ Trackman.prototype.initEventHandler = function() {
                 this.trackman.showAlert(msg['data']);
                 break;
             case 'session_end':
-                location.reload();
+                this.djsetId = null;
                 break;
         }
     };

--- a/wuvt/static/js/trackman/trackman.js
+++ b/wuvt/static/js/trackman/trackman.js
@@ -493,6 +493,15 @@ Trackman.prototype.fetchPlaylist = function(callback) {
 
                 callback();
             },
+            error: function(jqXHR, statusText, errorThrown) {
+                // if fetching the DJSet returns a 403, it belongs to another
+                // DJ and we can't use it
+                if(jqXHR.status == 403) {
+                    this.djsetId = null;
+                    this.playlistKeyed = [];
+                    callback();
+                }
+            },
         });
     } else {
         this.playlistKeyed = [];

--- a/wuvt/static/js/trackman/trackman.js
+++ b/wuvt/static/js/trackman/trackman.js
@@ -1313,6 +1313,13 @@ Trackman.prototype.initLogout = function() {
 
                     location.href = inst.baseUrl;
                 },
+                error: function(jqXHR, statusText, errorThrown) {
+                    if(jqXHR.responseJSON['ended'] != true) {
+                        alert(data['message']);
+                    }
+
+                    location.href = inst.baseUrl;
+                },
             });
         } else {
             location.href = inst.baseUrl;

--- a/wuvt/static/js/trackman/trackman.js
+++ b/wuvt/static/js/trackman/trackman.js
@@ -377,8 +377,9 @@ Trackman.prototype.logTrack = function(track, callback) {
         });
     } else {
         // create a new DJSet, start using it, and try again
+        var inst = this;
         this.createDJSet(function() {
-            this.logTrack(track, callback);
+            inst.logTrack(track, callback);
         });
     }
 };

--- a/wuvt/static/js/trackman/trackman.js
+++ b/wuvt/static/js/trackman/trackman.js
@@ -368,8 +368,9 @@ Trackman.prototype.logTrack = function(track, callback) {
             error: function(jqXHR, statusText, errorThrown) {
                 if(jqXHR.responseJSON['onair'] == false) {
                     this.djsetId = null;
-                    this.logTrack(track, callback);
                     this.updateOnAir();
+
+                    this.logTrack(track, callback);
                 } else {
                     inst.handleError(jqXHR, statusText, errorThrown);
                 }
@@ -400,7 +401,10 @@ Trackman.prototype.createDJSet = function(callback) {
                 callback();
             }
         },
-        error: this.handleError,
+        error: function(jqXHR, statusText, errorThrown) {
+            this.updateOnAir();
+            this.handleError(jqXHR, statusText, errorThrown);
+        },
     });
 };
 

--- a/wuvt/static/js/trackman/trackman.js
+++ b/wuvt/static/js/trackman/trackman.js
@@ -372,7 +372,7 @@ Trackman.prototype.logTrack = function(track, callback) {
 
                     this.logTrack(track, callback);
                 } else {
-                    inst.handleError(jqXHR, statusText, errorThrown);
+                    this.handleError(jqXHR, statusText, errorThrown);
                 }
             },
         });

--- a/wuvt/templates/trackman/log.html
+++ b/wuvt/templates/trackman/log.html
@@ -27,9 +27,16 @@
                 Let me play longer songs
             </label>
 
-            <button type="button" class="btn btn-warning" id="trackman_logout_btn">
-                <span class="glyphicon glyphicon-log-out"></span>
-                Logout
+            <div class="btn-group" role="group">
+                <button type="button" class="btn btn-default" id="on_air_btn">
+                    <span class="glyphicon glyphicon-flash"></span>
+                    On Air
+                </button>
+
+                <button type="button" class="btn btn-warning" id="trackman_logout_btn">
+                    <span class="glyphicon glyphicon-log-out"></span>
+                    Logout
+                </button>
             </button>
         </form>
     </div>

--- a/wuvt/templates/trackman/log.html
+++ b/wuvt/templates/trackman/log.html
@@ -307,6 +307,6 @@
 {% endblock %}
 {% block js %}
 {{ super() }}
-<script src="{{ url_for('static', filename='js/trackman/trackman.js', v=17) }}"></script>
+<script src="{{ url_for('static', filename='js/trackman/trackman.js', v=18) }}"></script>
 <script src="{{ url_for('trackman_private.log_js') }}"></script>
 {% endblock %}

--- a/wuvt/trackman/admin_views.py
+++ b/wuvt/trackman/admin_views.py
@@ -100,15 +100,7 @@ def log():
         djset = DJSet.query.get_or_404(djset_id)
         if djset.dtend is not None:
             # This is a logged out DJSet
-
-            flash("""\
-Your session has ended; you were either automatically logged out for inactivity
-or you pressed the Logout button somewhere else.
-""")
-            session.pop('dj_id', None)
             session.pop('djset_id', None)
-
-            return redirect(url_for('.login'))
 
     renew_dj_lease()
 

--- a/wuvt/trackman/api/v1/djset.py
+++ b/wuvt/trackman/api/v1/djset.py
@@ -78,7 +78,8 @@ class DJSetEnd(TrackmanResource):
             abort(403, success=False)
 
         if djset.dtend is not None:
-            abort(400, success=False, message="DJSet has already ended")
+            abort(400, success=False, message="DJSet has already ended",
+                  ended=True)
 
         with Lock(redis_conn, 'end_djset', expire=60, auto_renewal=True):
             djset.dtend = datetime.datetime.utcnow()

--- a/wuvt/trackman/view_utils.py
+++ b/wuvt/trackman/view_utils.py
@@ -56,7 +56,8 @@ def require_onair(f):
     @wraps(f)
     def require_onair_wrapper(*args, **kwargs):
         if not check_onair(session.get('djset_id', None)):
-            abort(403, message="You must be on-air to use that feature.")
+            abort(403, message="You must be on-air to use that feature.",
+                  onair=False)
         else:
             return f(*args, **kwargs)
     return require_onair_wrapper


### PR DESCRIPTION
* Create a new DJSet when the current one expires
* Don't redirect when the DJSet ends, just set the `djset_id` to null; in the
  future we may want to consider adding a notification.
* If the request to fetch the playlist for the current DJSet fails, set the
  `djset_id` to null.