### PR TITLE
Fix #329 and create nicer link for CSV download

### DIFF
--- a/wuvt/admin/views.py
+++ b/wuvt/admin/views.py
@@ -503,18 +503,19 @@ def library_redirect(path=None):
 @bp.route('/donate/csv')
 @login_required
 def donate_csv_download():
-    csvHeaders = ["id", "name", "phone", "date", "address", "useragent", "dj",
-                  "thanks", "firsttime", "dcomment", "premiums", "address1",
-                  "address2", "city", "state", "zip", "amount", "recurring",
-                  "paiddate", "shippeddate", "shirtsize", "shirtcolor",
-                  "sweatshirtsize", "method", "custid", "comments"]
+    csvHeaders = ["id", "name", "email", "phone", "date", "address",
+                  "useragent", "dj", "thanks", "firsttime", "dcomment",
+                  "premiums", "address1", "address2", "city", "state", "zip",
+                  "amount", "recurring", "paiddate", "shippeddate",
+                  "shirtsize", "shirtcolor", "sweatshirtsize", "method",
+                  "custid", "comments"]
     orders = Order.query.\
         order_by(db.desc(Order.id))
     f = io.StringIO()
     writer = csv.writer(f)
     writer.writerow(csvHeaders)
     for o in orders:
-        fields = [o.id, o.name, o.phone, o.placed_date, o.remote_addr,
+        fields = [o.id, o.name, o.email, o.phone, o.placed_date, o.remote_addr,
                   o.user_agent, o.dj, o.thank_on_air, o.first_time,
                   o.donor_comment, o.premiums, o.address1, o.address2, o.city,
                   o.state, o.zipcode, o.amount, o.recurring, o.paid_date,

--- a/wuvt/templates/admin/donation_index.html
+++ b/wuvt/templates/admin/donation_index.html
@@ -21,7 +21,13 @@
             <small>Last reset: {{ last_stats_reset|datetime }}</small>
 {% endif %}
         </form>
-        <a href="/admin/donate/csv">CSV Export</a>
+    </div>
+</div>
+<div class="panel panel-default">
+    <div class="panel-body">
+    	<div class="list-group">
+            <a href="/admin/donate/csv" class="list-group-item">CSV Export</a>
+        </div>
     </div>
 </div>
 

--- a/wuvt/templates/admin/donation_index.html
+++ b/wuvt/templates/admin/donation_index.html
@@ -21,13 +21,7 @@
             <small>Last reset: {{ last_stats_reset|datetime }}</small>
 {% endif %}
         </form>
-    </div>
-</div>
-<div class="panel panel-default">
-    <div class="panel-body">
-    	<div class="list-group">
-            <a href="/admin/donate/csv" class="list-group-item">CSV Export</a>
-        </div>
+        <a href="/admin/donate/csv">CSV Export</a>
     </div>
 </div>
 


### PR DESCRIPTION
CSV download is now wrapped in same format that we use for "reports" on
the library interface. CSV now includes emails. Fixes #329 