### PR TITLE
Remove "Let me play longer songs" checkbox

### DIFF
--- a/wuvt/defaults.py
+++ b/wuvt/defaults.py
@@ -28,8 +28,8 @@ NAV_TOP_SECTIONS = [
 ]
 
 # DJ activity timer for automation/DJ logout in seconds
-DJ_TIMEOUT = 30 * 60
-EXTENDED_DJ_TIMEOUT = 120 * 60
+DJ_TIMEOUT = 60 * 60
+EXTENDED_DJ_TIMEOUT = 180 * 60
 NO_DJ_TIMEOUT = 5 * 60
 
 CELERY_BROKER_URL = REDIS_URL

--- a/wuvt/static/js/trackman/trackman.js
+++ b/wuvt/static/js/trackman/trackman.js
@@ -118,64 +118,6 @@ Trackman.prototype.validateTrack = function(track) {
     return true;
 };
 
-// Autologout {{{
-Trackman.prototype.initAutologout = function() {
-    this.extendAutologout = false;
-
-    $.ajax({
-        url: this.baseUrl + "/api/autologout",
-        dataType: "json",
-        success: this.updateAutologout,
-    });
-    $('#id_extend_autologout').on('change', null, {'instance': this},
-                                  this.toggleAutologout);
-};
-
-Trackman.prototype.toggleAutologout = function(ev) {
-    var inst = ev.data.instance;
-
-    $('#id_extend_autologout').prop('disabled', true);
-
-    var formdata = {};
-
-    if($('#id_extend_autologout').prop('checked')) {
-        formdata['autologout'] = "disable";
-    } else {
-        formdata['autologout'] = "enable";
-    }
-
-    $.ajax({
-        url: inst.baseUrl + "/api/autologout",
-        data: formdata,
-        dataType: "json",
-        type: "POST",
-        context: inst,
-        success: inst.updateAutologout,
-        error: inst.updateAutologoutError,
-    });
-};
-
-Trackman.prototype.updateAutologout = function(data) {
-    $('#id_extend_autologout').prop('disabled', false);
-
-    if(data['success'] == false) {
-        alert(data['message']);
-    } else if(data['autologout'] == true) {
-        this.extendAutologout = false;
-    } else {
-        this.extendAutologout = true;
-    }
-
-    $('#id_extend_autologout').prop('checked', this.extendAutologout);
-};
-
-Trackman.prototype.updateAutologoutError = function(jqXHR, textStatus, errorThrown) {
-    $('#id_extend_autologout').prop('disabled', false);
-    this.handleError(jqXHR, textStatus, errorThrown);
-    $('#id_extend_autologout').prop('checked', this.extendAutologout);
-};
-// }}}
-
 // Queue {{{
 Trackman.prototype.initQueue = function() {
     this.queue = [];
@@ -1382,7 +1324,6 @@ Trackman.prototype.init = function() {
     this.initOnAir();
     this.initResizeHandler();
     this.initEventHandler();
-    this.initAutologout();
     this.initRotations();
     this.initQueue();
     this.initPlaylist();

--- a/wuvt/templates/trackman/log.html
+++ b/wuvt/templates/trackman/log.html
@@ -21,12 +21,6 @@
                 Email me my playlist
             </label>
 
-            <label class="checkbox-inline">
-                <input type="checkbox" name="extend_autologout"
-                    id="id_extend_autologout" />
-                Let me play longer songs
-            </label>
-
             <div class="btn-group" role="group">
                 <button type="button" class="btn btn-default" id="on_air_btn">
                     <span class="glyphicon glyphicon-flash"></span>
@@ -314,6 +308,6 @@
 {% endblock %}
 {% block js %}
 {{ super() }}
-<script src="{{ url_for('static', filename='js/trackman/trackman.js', v=18) }}"></script>
+<script src="{{ url_for('static', filename='js/trackman/trackman.js', v=19) }}"></script>
 <script src="{{ url_for('trackman_private.log_js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
This change also changes the default `DJ_TIMEOUT` to 60 minutes and `EXTENDED_DJ_TIMEOUT` to 180 minutes (3 hours).

I've left the autologout API in place; other clients to the Trackman API may still want to use it.