### PR TITLE
Prefer audio/aac stream

### DIFF
--- a/wuvt/static/js/stream.js
+++ b/wuvt/static/js/stream.js
@@ -1,8 +1,8 @@
 // @license magnet:?xt=urn:btih:0b31508aeb0634b347b8270c7bee4d411b5d4109&dn=agpl-3.0.txt AGPL-v3.0
 
 var streams = [
-    ['audio/ogg', "https://stream.wuvt.vt.edu/wuvt.ogg"],
-    ['audio/aac', "https://stream.wuvt.vt.edu/wuvt.aac"]
+    ['audio/aac', "https://stream.wuvt.vt.edu/wuvt.aac"],
+    ['audio/ogg', "https://stream.wuvt.vt.edu/wuvt.ogg"]
 ];
 var streamPlaying = false;
 var defaultVolume = 50;


### PR DESCRIPTION
We've gotten reports that the Vorbis stream still has issues for some
people. I think the best option is to just prefer the AAC stream since
support seems to be much better.