### PR TITLE
Pre-create redis user to avoid uwsgi using the wrong uid/gid.

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,6 +4,9 @@ FROM python:3
 # temporary database that is stored in the container, which you definitely
 # don't want for production.
 
+# precreate a redis user with a known uid/gid for uwsgi
+RUN useradd -d /var/lib/redis -r -s /bin/false -u 500 -U redis
+
 RUN apt-get update \
         && apt-get install -y \
             git \

--- a/uwsgi_docker.ini
+++ b/uwsgi_docker.ini
@@ -41,7 +41,7 @@ py-autoreload = 1
 module = wuvt
 callable = app
 
-attach-daemon2 = cmd=redis-server /etc/redis/redis.conf,pidfile=/var/run/redis/redis-server.pid,uid=106,gid=111
+attach-daemon2 = cmd=redis-server /etc/redis/redis.conf,pidfile=/var/run/redis/redis-server.pid,uid=500,gid=500
 
 add-header = X-Frame-Options: SAMEORIGIN
 


### PR DESCRIPTION
I noticed when attempting to start the dev docker container the site wouldn't come up and there were quite a few redis errors in the console.

I tracked the issue down to uwsgi trying to run the daemon with the incorrect uid/gid:
https://github.com/wuvt/wuvt-site/blob/master/uwsgi_docker.ini#L44

Looking at the history of that file, it looks like the uid/gid had been changed a few times - perhaps a bit of a bandaid patch.

There were a few possible solutions.
1) Change the uid/gid used again. In my fresh docker container they were uid=101 and gid=102, if my memory serves.
2) Remove the uid/gid options and just have redis run as root.
3) Pre-create a redis user and group with a high enough uid/gid that we would not risk clobbering it again.

This PR employs the third option as I think it is the most elegant.

Thanks