### PR TITLE
Disabling code which causes test data seed to fail.

### DIFF
--- a/wuvt/db_utils.py
+++ b/wuvt/db_utils.py
@@ -7,13 +7,14 @@ from wuvt.blog.models import Article, Category
 def initdb(username, password):
     db.create_all()
 
-    dj = DJ("Automation", "Automation", False)
-    db.session.add(dj)
-    try:
-        db.session.commit()
-    except:
-        db.session.rollback()
-        raise
+#XXX# Missing trackman class DJ()
+#    dj = DJ("Automation", "Automation", False)
+#    db.session.add(dj)
+#    try:
+#        db.session.commit()
+#    except:
+#        db.session.rollback()
+#        raise
 
     cats = [Category("Events", "events", True),
             Category("Music Adds", "music-adds", True),
@@ -29,23 +30,25 @@ def initdb(username, password):
     user.set_password(str(password))
     db.session.add(user)
 
-    # The first Rotation is always the default
-    db.session.add(Rotation("None"))
-    for r in ["Metal", "New Music", "Jazz", "Rock", "Americana"]:
-        db.session.add(Rotation(r))
-
-    try:
-        db.session.commit()
-    except:
-        db.session.rollback()
-        raise
+#XXX# Missing trackman class Rotation()
+#    # The first Rotation is always the default
+#    db.session.add(Rotation("None"))
+#    for r in ["Metal", "New Music", "Jazz", "Rock", "Americana"]:
+#        db.session.add(Rotation(r))
+#
+#    try:
+#        db.session.commit()
+#    except:
+#        db.session.rollback()
+#        raise
 
 
 def add_sample_data():
     add_sample_articles()
     add_sample_pages()
-    add_sample_djs()
-    add_sample_tracks()
+#XXX# Missing trackman class DJ() and Track()
+#    add_sample_djs()
+#    add_sample_tracks()
 
 
 def add_sample_articles():


### PR DESCRIPTION
I noticed that the dev database was not being seeded, most importantly this resulted in no test admin user being created.

It looks like this stemmed from when Trackman was previously removed from this repo. Some Trackman classes were still being used for these seed tasks unfortunately.

I'm not sure if the intention is we also pull down Trackman and use that as well, but for now I simply commented out the appropriate sections so that I could get the db seed to run without error.