### PR TITLE
donation reset stats button to use btn-danger bootstrap class

### DIFF
--- a/wuvt/templates/admin/donation_index.html
+++ b/wuvt/templates/admin/donation_index.html
@@ -13,7 +13,7 @@
 
         <form method="post">
             <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
-            <button name="reset_stats" type="submit" class="btn btn-default btn-sm">
+            <button name="reset_stats" type="submit" class="btn btn-danger btn-sm">
                 <span class="glyphicon glyphicon-dashboard"></span>
                 Reset Stats
             </button>


### PR DESCRIPTION
Fixes #340 

Reset stats is now a scary red button.

Not tested - I wasn't able to get the donation page in the admin panel to load correctly, and I haven't gotten to the bottom of this yet.