### PR TITLE
Add Sentry support for error handling 

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -21,6 +21,7 @@ python-redis-lock
 pytz
 redis
 requests
+sentry-sdk[flask]
 sqlalchemy>=1.2.0
 SQLAlchemy-Utils
 stripe

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,10 +4,13 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
-alembic==0.9.9            # via flask-migrate
-aniso8601==3.0.0          # via flask-restful
-bleach==2.1.3
-certifi==2018.4.16        # via requests
+alembic==1.0.1            # via flask-migrate
+aniso8601==3.0.2          # via flask-restful
+asn1crypto==0.24.0        # via cryptography
+bleach==3.0.2
+blinker==1.4              # via sentry-sdk
+certifi==2018.10.15       # via requests, sentry-sdk
+cffi==1.11.5              # via cryptography
 chardet==3.0.4            # via requests
 click==6.7
 flask-caching==1.4.0
@@ -20,8 +23,8 @@ flask==0.12.2
 html5lib==1.0.1           # via bleach
 httplib2==0.11.3          # via oauth2client
 humanize==0.5.1
-idna==2.6                 # via requests
-itsdangerous==0.24        # via flask, flask-oidc
+idna==2.7                 # via cryptography, requests
+itsdangerous==1.0.0       # via flask, flask-oidc
 jinja2==2.10              # via flask
 mako==1.0.7               # via alembic
 markdown==2.6.11
@@ -29,23 +32,24 @@ markupsafe==1.0           # via jinja2, mako
 netaddr==0.7.19
 oauth2client==4.1.2       # via flask-oidc
 passlib==1.7.1
-psycopg2==2.7.4 --no-binary psycopg2
+psycopg2==2.7.4
 pyasn1-modules==0.2.1
 pyasn1==0.4.2
 pymysql==0.8.0
 python-dateutil==2.7.2
 python-editor==1.0.3
 python-redis-lock==3.2.0
-pytz==2018.4
+pytz==2018.5
 redis==2.10.6
-requests==2.18.4
-rsa==3.4.2                # via oauth2client
-six==1.11.0               # via bleach, flask-oidc, flask-restful, html5lib, oauth2client, python-dateutil, sqlalchemy-utils
-sqlalchemy-utils==0.33.2
-sqlalchemy==1.2.6
-stripe==1.79.1
+requests==2.20.0
+rsa==4.0                  # via oauth2client
+sentry-sdk[flask]==0.4.2
+six==1.11.0               # via bleach, cryptography, flask-oidc, flask-restful, oauth2client, python-dateutil, sqlalchemy-utils
+sqlalchemy-utils==0.33.6
+sqlalchemy==1.2.12
+stripe==2.10.1
 unidecode==1.0.22
-urllib3==1.22             # via requests
-webencodings==0.5.1       # via html5lib
+urllib3==1.24             # via requests, sentry-sdk
+webencodings==0.5.1       # via bleach
 werkzeug==0.14.1          # via flask
 wtforms==2.1              # via flask-wtf

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,52 +4,52 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
-alembic==1.0.1            # via flask-migrate
+alembic==1.0.0            # via flask-migrate
 aniso8601==3.0.2          # via flask-restful
 asn1crypto==0.24.0        # via cryptography
-bleach==3.0.2
+bleach==3.0.0
 blinker==1.4              # via sentry-sdk
-certifi==2018.10.15       # via requests, sentry-sdk
+certifi==2018.8.24        # via requests, sentry-sdk
 cffi==1.11.5              # via cryptography
 chardet==3.0.4            # via requests
-click==6.7
+click==7.0
+cryptography==2.3.1       # via pymysql
 flask-caching==1.4.0
-flask-migrate==2.1.1
+flask-migrate==2.2.1
 flask-oidc==1.4.0
 flask-restful==0.3.6
 flask-sqlalchemy==2.3.2
 flask-wtf==0.14.2
-flask==0.12.2
-html5lib==1.0.1           # via bleach
+flask==1.0.2
 httplib2==0.11.3          # via oauth2client
 humanize==0.5.1
 idna==2.7                 # via cryptography, requests
-itsdangerous==1.0.0       # via flask, flask-oidc
+itsdangerous==0.24        # via flask, flask-oidc
 jinja2==2.10              # via flask
 mako==1.0.7               # via alembic
-markdown==2.6.11
+markdown==3.0.1
 markupsafe==1.0           # via jinja2, mako
 netaddr==0.7.19
-oauth2client==4.1.2       # via flask-oidc
+oauth2client==4.1.3       # via flask-oidc
 passlib==1.7.1
-psycopg2==2.7.4
-pyasn1-modules==0.2.1
-pyasn1==0.4.2
-pymysql==0.8.0
-python-dateutil==2.7.2
+psycopg2==2.7.5
+pyasn1-modules==0.2.2
+pyasn1==0.4.4
+pycparser==2.19           # via cffi
+pymysql==0.9.2
+python-dateutil==2.7.3
 python-editor==1.0.3
 python-redis-lock==3.2.0
 pytz==2018.5
 redis==2.10.6
-requests==2.20.0
+requests==2.19.1
 rsa==4.0                  # via oauth2client
-sentry-sdk[flask]==0.4.2
 six==1.11.0               # via bleach, cryptography, flask-oidc, flask-restful, oauth2client, python-dateutil, sqlalchemy-utils
-sqlalchemy-utils==0.33.6
+sqlalchemy-utils==0.33.5
 sqlalchemy==1.2.12
 stripe==2.10.1
 unidecode==1.0.22
-urllib3==1.24             # via requests, sentry-sdk
+urllib3==1.23             # via requests, sentry-sdk
 webencodings==0.5.1       # via bleach
 werkzeug==0.14.1          # via flask
-wtforms==2.1              # via flask-wtf
+wtforms==2.2.1            # via flask-wtf

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -7,6 +7,7 @@ touch-reload = /srv/http/wuvt-site/reload.txt
 processes = 20
 offload-threads = 4
 harakiri = 30
+enable-threads = 1
 
 chdir = /srv/http/wuvt-site
 plugins = python,sse_offload
@@ -34,6 +35,7 @@ http-socket = :9090
 processes = 2
 offload-threads = 1
 harakiri = 30
+enable-threads = 1
 
 plugins = python,sse_offload
 py-autoreload = 1

--- a/uwsgi_docker.ini
+++ b/uwsgi_docker.ini
@@ -7,6 +7,7 @@ https = :8443,/data/ssl/cert.pem,/data/ssl/privkey.pem,ECDHE-RSA-AES256-GCM-SHA3
 processes = 10
 offload-threads = 4
 harakiri = 90
+enable-threads = 1
 
 module = wuvt
 callable = app
@@ -36,6 +37,7 @@ http = :8080
 processes = 2
 offload-threads = 1
 harakiri = 90
+enable-threads = 1
 
 py-autoreload = 1
 module = wuvt

--- a/wuvt/__init__.py
+++ b/wuvt/__init__.py
@@ -11,6 +11,8 @@ import redis
 from . import defaults
 import uuid
 import datetime
+import sentry_sdk
+from sentry_sdk.integrations.flask import FlaskIntegration
 
 json_mimetypes = ['application/json']
 
@@ -124,6 +126,10 @@ auth_manager.init_app(app)
 if app.config['AUTH_METHOD'] == 'oidc':
     from wuvt.auth.oidc import OpenIDConnect
     oidc = OpenIDConnect(app)
+
+if len(app.config['SENTRY_DSN']) > 0:
+    sentry_sdk.init(app.config['SENTRY_DSN'],
+                    integrations=[FlaskIntegration()])
 
 
 @app.context_processor

--- a/wuvt/defaults.py
+++ b/wuvt/defaults.py
@@ -62,3 +62,5 @@ AUTH_ROLE_GROUPS = {
     'library': ['librarians'],
     'missioncontrol': ['missioncontrol'],
 }
+
+SENTRY_DSN = ""


### PR DESCRIPTION
In a future pull request, I will be removing support for sending exception emails directly. Moving to Sentry will help reduce email clutter and improve response time; for example, we could have it send a notification directly to Slack when the website throws an exception.

I also updated the dependencies in requirements.txt