### PR TITLE
Popup confirmation for donation reset.

### DIFF
--- a/wuvt/static/js/admin/donation_index.js
+++ b/wuvt/static/js/admin/donation_index.js
@@ -4,4 +4,8 @@ $('#donations').DataTable({
     'order': [[3, 'desc']],
 });
 
+function confirm_delete(e){
+    if(!confirm('Are you sure you want to reset donation stats?'))e.preventDefault();
+}
+
 // @license-end

--- a/wuvt/templates/admin/donation_index.html
+++ b/wuvt/templates/admin/donation_index.html
@@ -13,7 +13,7 @@
 
         <form method="post">
             <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
-            <button name="reset_stats" type="submit" class="btn btn-danger btn-sm">
+            <button name="reset_stats" type="submit" class="btn btn-danger btn-sm" onclick="confirm_delete(event)">
                 <span class="glyphicon glyphicon-dashboard"></span>
                 Reset Stats
             </button>


### PR DESCRIPTION
Fixes #280 

Just a simple onclick confirm. I think it could be upgraded in the future to use a nice looking modal, but this is a good start.