### PR TITLE
Sanitize donor phone numbers

### DIFF
--- a/wuvt/donate/views.py
+++ b/wuvt/donate/views.py
@@ -62,6 +62,8 @@ def process_order(method):
         # like (540) 555-5555 instead of 540-555-5555 or 5405555555.
         order.phone = ''.join([char for char in request.form['phone'] if char
                                in "0123456789"])
+        if len(order.phone) > 12:
+            return False, "Phone number exceeded max length 12"
 
     if 'comment' in request.form:
         order.donor_comment = request.form['comment'].strip()

--- a/wuvt/donate/views.py
+++ b/wuvt/donate/views.py
@@ -57,8 +57,11 @@ def process_order(method):
     order.set_user_agent(request.user_agent)
 
     if 'phone' in request.form:
-        # if a phone number is provided, set it
-        order.phone = request.form['phone'].strip()
+        # Removes anything non-numeric from the phone string, so that we
+        # no longer have exceptions when Mission Control users use something
+        # like (540) 555-5555 instead of 540-555-5555 or 5405555555.
+        order.phone = ''.join([char for char in request.form['phone'] if char
+                               in "0123456789"])
 
     if 'comment' in request.form:
         order.donor_comment = request.form['comment'].strip()


### PR DESCRIPTION
Historically, we've had improper phone numbers ("improper" meaning any
number string that contained any special characters except for -) throw
exceptions on donation since the Postgres database expects VARCHAR(12).
This commit fixes that by reducing any given input down to just numbers.