### PR TITLE
Cascade 404 errors from Trackman (fix #373)

### DIFF
--- a/wuvt/playlists/view_utils.py
+++ b/wuvt/playlists/view_utils.py
@@ -11,8 +11,12 @@ def call_api(path, method, *args, **kwargs):
     path = path.format(*args, **kwargs)
     url = "{0}/api{1}".format(current_app.config['TRACKMAN_URL'], path)
     r = requests.request(method, url)
-    r.raise_for_status()
-    return r.json()
+
+    if r.status_code == 404:
+        abort(404)
+    else:
+        r.raise_for_status()
+        return r.json()
 
 
 def tracklog_serialize(t):


### PR DESCRIPTION
If the Trackman API returns a 404 error, we should as well.