### PR TITLE
Add authenticated user to uWSGI logs

### DIFF
--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -28,6 +28,8 @@ pull-header = X-SSE-Channel SSE_CHANNEL
 pull-header = X-SSE-Password SSE_PASSWORD
 response-route-if-not = empty:${SSE_OFFLOAD} sse:server=${SSE_SERVER},subscribe=${SSE_CHANNEL},password=${SSE_PASSWORD}
 
+log-format = [pid: %(pid)|app: -|req: -/-] %(addr) (%(app_user)) {%(vars) vars in %(pktsize) bytes} [%(ctime)] %(method) %(uri) => generated %(rsize) bytes in %(msecs) msecs (%(proto) %(status)) %(headers) headers in %(hsize) bytes (%(switches) switches on core %(core))
+
 [dev]
 procname-prefix-spaced = wuvt-site
 master = 1
@@ -58,3 +60,5 @@ pull-header = X-SSE-Server SSE_SERVER
 pull-header = X-SSE-Channel SSE_CHANNEL
 pull-header = X-SSE-Password SSE_PASSWORD
 response-route-if-not = empty:${SSE_OFFLOAD} sse:server=${SSE_SERVER},subscribe=${SSE_CHANNEL},password=${SSE_PASSWORD}
+
+log-format = [pid: %(pid)|app: -|req: -/-] %(addr) (%(app_user)) {%(vars) vars in %(pktsize) bytes} [%(ctime)] %(method) %(uri) => generated %(rsize) bytes in %(msecs) msecs (%(proto) %(status)) %(headers) headers in %(hsize) bytes (%(switches) switches on core %(core))

--- a/uwsgi_docker.ini
+++ b/uwsgi_docker.ini
@@ -27,6 +27,8 @@ pull-header = X-SSE-Channel SSE_CHANNEL
 pull-header = X-SSE-Password SSE_PASSWORD
 response-route-if-not = empty:${SSE_OFFLOAD} sse:server=${SSE_SERVER},subscribe=${SSE_CHANNEL},password=${SSE_PASSWORD}
 
+log-format = [pid: %(pid)|app: -|req: -/-] %(addr) (%(app_user)) {%(vars) vars in %(pktsize) bytes} [%(ctime)] %(method) %(uri) => generated %(rsize) bytes in %(msecs) msecs (%(proto) %(status)) %(headers) headers in %(hsize) bytes (%(switches) switches on core %(core))
+
 [dev]
 procname-prefix-spaced = wuvt-site
 master = 1
@@ -58,3 +60,5 @@ pull-header = X-SSE-Server SSE_SERVER
 pull-header = X-SSE-Channel SSE_CHANNEL
 pull-header = X-SSE-Password SSE_PASSWORD
 response-route-if-not = empty:${SSE_OFFLOAD} sse:server=${SSE_SERVER},subscribe=${SSE_CHANNEL},password=${SSE_PASSWORD}
+
+log-format = [pid: %(pid)|app: -|req: -/-] %(addr) (%(app_user)) {%(vars) vars in %(pktsize) bytes} [%(ctime)] %(method) %(uri) => generated %(rsize) bytes in %(msecs) msecs (%(proto) %(status)) %(headers) headers in %(hsize) bytes (%(switches) switches on core %(core))

--- a/wuvt/auth/auth_manager.py
+++ b/wuvt/auth/auth_manager.py
@@ -154,7 +154,7 @@ class AuthManager(object):
                     self.db.session.rollback()
                     raise
 
-        _request_ctx_stack.top.user = None
+        _request_ctx_stack.top.user = AnonymousUserMixin()
         _request_ctx_stack.top.user_roles = set([])
         return True
 


### PR DESCRIPTION
To make auditing and debugging easier, it is helpful to include the
current authenticated user in the request log. We do this by setting a
uWSGI log variable in the application and overriding the uWSGI log
format to use this variable instead of the REMOTE_USER of the request.

Unfortunately, uWSGI is weird and we lose some information when we
override the log format, like the app ID and whatever "req" specifies in
the logs. This shouldn't affect anything we're doing, but it's
unfortunate nonetheless.

Also, when there is no user logged in or the Python application is
bypassed, the user will be "-" instead of the empty string.